### PR TITLE
[CLEANUP] Make the assert calls in the unit tests static

### DIFF
--- a/tests/action/class.tx_mkforms_tests_action_FormBase_testcase.php
+++ b/tests/action/class.tx_mkforms_tests_action_FormBase_testcase.php
@@ -213,78 +213,78 @@ public function test_processForm() {
 				'AMEOSFORMIDABLE_VIEWSTATE' => '',
 				'AMEOSFORMIDABLE_SUBMITTED' => 'AMEOSFORMIDABLE_EVENT_SUBMIT_FULL',
 				'AMEOSFORMIDABLE_SUBMITTER' => '',
-				'MKFORMS_REQUEST_TOKEN' => $this->getAction()->getForm()->getCsrfProtectionToken()
+				'MKFORMS_REQUEST_TOKEN' => self::getAction()->getForm()->getCsrfProtectionToken()
 			);
-		$GLOBALS['TSFE']->fe_user->setKey('ses', 'mkforms', array('requestToken' => array($this->getAction()->getForm()->getFormId() => $this->getAction()->getForm()->getCsrfProtectionToken())));
+		$GLOBALS['TSFE']->fe_user->setKey('ses', 'mkforms', array('requestToken' => array(self::getAction()->getForm()->getFormId() => self::getAction()->getForm()->getCsrfProtectionToken())));
 		$GLOBALS['TSFE']->fe_user->storeSessionData();
 
 		$_POST['radioTestForm'] = $sData;
 
-		$action = $this->getAction();
+		$action = self::getAction();
 
 		// die Daten werden für den view in formData gespeichert
 		$formData = $action->getConfigurations()->getViewData()->offsetGet('formData');
 
-		$this->assertTrue(isset($formData['submitmode']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['submitmode'], 'full', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['submitmode']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['submitmode'], 'full', 'LINE:'.__LINE__);
 
-		$this->assertTrue(is_array($formData['widget']), 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget']['text']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['text'], 'Eins', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget']['radiobutton']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['radiobutton'], '3', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget']['listbox']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['listbox'], '7', 'LINE:'.__LINE__);
-		$this->assertTrue(is_array($formData['widget']['checkbox']), 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget']['checkbox']['5']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['checkbox']['5'], '6', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget']['checkbox']['8']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['checkbox']['8'], '9', 'LINE:'.__LINE__);
-		$this->assertTrue(is_array($formData['widget1']), 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget1']['text']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget1']['text'], 'Zwei', 'LINE:'.__LINE__);
-		$this->assertTrue(is_array($formData['widget2']), 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget2']['text']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget2']['text'], 'Zwei', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['textarea']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['textarea'], 'Sehr Lang!', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widgetlister']['selected']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widgetlister']['selected'], '5', 'LINE:'.__LINE__);
-		$this->assertFalse(isset($formData['widgetlister']['notInXml']), 'LINE:'.__LINE__);
+		self::assertTrue(is_array($formData['widget']), 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['text']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['text'], 'Eins', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['radiobutton']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['radiobutton'], '3', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['listbox']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['listbox'], '7', 'LINE:'.__LINE__);
+		self::assertTrue(is_array($formData['widget']['checkbox']), 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['checkbox']['5']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['checkbox']['5'], '6', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['checkbox']['8']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['checkbox']['8'], '9', 'LINE:'.__LINE__);
+		self::assertTrue(is_array($formData['widget1']), 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget1']['text']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget1']['text'], 'Zwei', 'LINE:'.__LINE__);
+		self::assertTrue(is_array($formData['widget2']), 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget2']['text']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget2']['text'], 'Zwei', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['textarea']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['textarea'], 'Sehr Lang!', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widgetlister']['selected']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widgetlister']['selected'], '5', 'LINE:'.__LINE__);
+		self::assertFalse(isset($formData['widgetlister']['notInXml']), 'LINE:'.__LINE__);
 		for($i=1; $i <=5 ; $i++) {
-			$this->assertTrue(is_array($formData['widgetlister'][$i]['listerdata']), $i.' LINE:'.__LINE__);
-			$this->assertTrue(isset($formData['widgetlister'][$i]['listerdata']['uid']), $i.' LINE:'.__LINE__);
-			$this->assertEquals($formData['widgetlister'][$i]['listerdata']['uid'], $i, $i.' LINE:'.__LINE__);
-			$this->assertTrue(isset($formData['widgetlister'][$i]['listerdata']['title']), $i.' LINE:'.__LINE__);
-			$this->assertEquals($formData['widgetlister'][$i]['listerdata']['title'], 'Titel '.$i, $i.' LINE:'.__LINE__);
+			self::assertTrue(is_array($formData['widgetlister'][$i]['listerdata']), $i.' LINE:'.__LINE__);
+			self::assertTrue(isset($formData['widgetlister'][$i]['listerdata']['uid']), $i.' LINE:'.__LINE__);
+			self::assertEquals($formData['widgetlister'][$i]['listerdata']['uid'], $i, $i.' LINE:'.__LINE__);
+			self::assertTrue(isset($formData['widgetlister'][$i]['listerdata']['title']), $i.' LINE:'.__LINE__);
+			self::assertEquals($formData['widgetlister'][$i]['listerdata']['title'], 'Titel '.$i, $i.' LINE:'.__LINE__);
 			//sollte entfernt werden da nicht im xml
-			$this->assertFalse(isset($formData['widgetlister'][$i]['listerdata']['notInXml']), $i.' LINE:'.__LINE__);
+			self::assertFalse(isset($formData['widgetlister'][$i]['listerdata']['notInXml']), $i.' LINE:'.__LINE__);
 		}
 		//submit
-		$this->assertTrue(isset($formData['widget']['submit']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['submit'], '1', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['submit']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['submit'], '1', 'LINE:'.__LINE__);
 		//date
-		$this->assertTrue(isset($formData['widget']['date']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['date'], '426204000', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget']['date_mysql']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['date_mysql'], '1983-07-05', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['date']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['date'], '426204000', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['date_mysql']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['date_mysql'], '1983-07-05', 'LINE:'.__LINE__);
 		//addpostvars
-		$this->assertTrue(is_array($formData['addpostvars']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['addpostvars'][0]['action'], 'formData', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['addpostvars'][0]['params']['widget']['submit']), 'LINE:'.__LINE__);
+		self::assertTrue(is_array($formData['addpostvars']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['addpostvars'][0]['action'], 'formData', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['addpostvars'][0]['params']['widget']['submit']), 'LINE:'.__LINE__);
 		//addfields
-		$this->assertTrue(isset($formData['widget']['addfield']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['widget']['addfield'], 'addfield feld', 'LINE:'.__LINE__);
-		$this->assertFalse(isset($formData['widget']['remove']), 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget']['addfield']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['widget']['addfield'], 'addfield feld', 'LINE:'.__LINE__);
+		self::assertFalse(isset($formData['widget']['remove']), 'LINE:'.__LINE__);
 
 		//sollte entfernt werden
-		$this->assertFalse(isset($formData['widget']['thatDoesNotExistInTheXml']), 'LINE:'.__LINE__);
+		self::assertFalse(isset($formData['widget']['thatDoesNotExistInTheXml']), 'LINE:'.__LINE__);
 	}
 
 	public function test_handleRequest() {
-		$action = $this->getAction();
+		$action = self::getAction();
 
-		$this->assertEquals('tx_mkforms_action_FormBase', get_class($action), 'Wrong class given.');
+		self::assertEquals('tx_mkforms_action_FormBase', get_class($action), 'Wrong class given.');
 	}
 
 	/**
@@ -297,12 +297,12 @@ public function test_processForm() {
 				'AMEOSFORMIDABLE_SUBMITTED' => 'AMEOSFORMIDABLE_EVENT_SUBMIT_FULL',
 				'MKFORMS_REQUEST_TOKEN' => 'iAmInvalid'
 			);
-		$GLOBALS['TSFE']->fe_user->setKey('ses', 'mkforms', array('requestToken' => array($this->getAction()->getForm()->getFormId() => $this->getAction()->getForm()->getCsrfProtectionToken())));
+		$GLOBALS['TSFE']->fe_user->setKey('ses', 'mkforms', array('requestToken' => array(self::getAction()->getForm()->getFormId() => self::getAction()->getForm()->getCsrfProtectionToken())));
 		$GLOBALS['TSFE']->fe_user->storeSessionData();
 
 		$_POST['radioTestForm'] = $sData;
 
-		$action = $this->getAction();
+		$action = self::getAction();
 	}
 
 	public function test_fillForm() {
@@ -318,33 +318,33 @@ public function test_processForm() {
 		$sData['widget2']['text'] = 'Default Text 2';
 		$sData['textarea'] = 'Ganz Langer vordefinierter Text';
 
-		$action = $this->getAction();
+		$action = self::getAction();
 		$fillData = $action->fillForm($sData, $action->getForm());
 
 
-		$this->assertTrue(isset($fillData['widget-text']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget-text'], 'Default Text', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['widget-checkbox']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget-checkbox'], '8,6', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['widget-radiobutton']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget-radiobutton'], '7', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['widget-listbox']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget-listbox'], '7', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['widget-checksingle']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget-checksingle'], '1', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['widget1-text']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget1-text'], 'Default Text 1', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['widget2-text']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget2-text'], 'Default Text 2', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['textarea']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['textarea'], 'Ganz Langer vordefinierter Text', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($fillData['widget-widget1-widget2-text']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget-widget1-widget2-text'], 'Default Text', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget-text']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget-text'], 'Default Text', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget-checkbox']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget-checkbox'], '8,6', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget-radiobutton']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget-radiobutton'], '7', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget-listbox']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget-listbox'], '7', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget-checksingle']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget-checksingle'], '1', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget1-text']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget1-text'], 'Default Text 1', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget2-text']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget2-text'], 'Default Text 2', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['textarea']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['textarea'], 'Ganz Langer vordefinierter Text', 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget-widget1-widget2-text']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget-widget1-widget2-text'], 'Default Text', 'LINE:'.__LINE__);
 
 		//addfields
-		$this->assertTrue(isset($fillData['widget-addfield']), 'LINE:'.__LINE__);
-		$this->assertEquals($fillData['widget-addfield'], 'addfield feld', 'LINE:'.__LINE__);
-		$this->assertFalse(isset($fillData['widget-remove']), 'LINE:'.__LINE__);
+		self::assertTrue(isset($fillData['widget-addfield']), 'LINE:'.__LINE__);
+		self::assertEquals($fillData['widget-addfield'], 'addfield feld', 'LINE:'.__LINE__);
+		self::assertFalse(isset($fillData['widget-remove']), 'LINE:'.__LINE__);
 	}
 }
 

--- a/tests/api/class.tx_mkforms_tests_api_maindatahandler_testcase.php
+++ b/tests/api/class.tx_mkforms_tests_api_maindatahandler_testcase.php
@@ -103,21 +103,21 @@ class tx_mkforms_tests_api_maindatahandler_testcase extends tx_phpunit_testcase 
 		//einzelnes renderlet
 		$formData = $oHandler->getRdtValue_submit_edition('widget-thatDoesNotExistInTheXml3');
 		//wert sollte auf null gesetzt werden
-		$this->assertNull($formData,'wert für nicht existentes widget nicht auf null gesetzt');
+		self::assertNull($formData,'wert für nicht existentes widget nicht auf null gesetzt');
 
 		//renderlet box
 		$formData = $oHandler->getRdtValue_submit_edition('fieldset');
 
-		$this->assertTrue(isset($formData['texte']['input']['widget-text']), 'LINE:'.__LINE__);
-		$this->assertEquals($formData['texte']['input']['widget-text'], 'Eins', 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widget-checkbox']), 'LINE:'.__LINE__);
-		$this->assertEquals(array('item-5' => '6','item-8' => '9'),$formData['widget-checkbox'], 'LINE:'.__LINE__);
-		$this->assertTrue(isset($formData['widgetlister']), 'LINE:'.__LINE__);
-		$this->assertEquals(array(1 => array('listerdata-uid' => 1,'listerdata-title' => 'Titel 1',),2 => array('listerdata-uid' => 2,'listerdata-title' => 'Titel 2',),3 => array('listerdata-uid' => 3,'listerdata-title' => 'Titel 3',),4 => array('listerdata-uid' => 4,'listerdata-title' => 'Titel 4',),5 => array('listerdata-uid' => 5,'listerdata-title' => 'Titel 5',),'selected' => '5'),$formData['widgetlister'], 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['texte']['input']['widget-text']), 'LINE:'.__LINE__);
+		self::assertEquals($formData['texte']['input']['widget-text'], 'Eins', 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widget-checkbox']), 'LINE:'.__LINE__);
+		self::assertEquals(array('item-5' => '6','item-8' => '9'),$formData['widget-checkbox'], 'LINE:'.__LINE__);
+		self::assertTrue(isset($formData['widgetlister']), 'LINE:'.__LINE__);
+		self::assertEquals(array(1 => array('listerdata-uid' => 1,'listerdata-title' => 'Titel 1',),2 => array('listerdata-uid' => 2,'listerdata-title' => 'Titel 2',),3 => array('listerdata-uid' => 3,'listerdata-title' => 'Titel 3',),4 => array('listerdata-uid' => 4,'listerdata-title' => 'Titel 4',),5 => array('listerdata-uid' => 5,'listerdata-title' => 'Titel 5',),'selected' => '5'),$formData['widgetlister'], 'LINE:'.__LINE__);
 
 		//werte sollte entfernt wurden sein
-		$this->assertFalse(isset($formData['texte']['widget-thatDoesNotExistInTheXml1']),'wert für nicht existentes widget nicht auf null gesetzt');
-		$this->assertFalse(isset($formData['widget-thatDoesNotExistInTheXml2']),'wert für nicht existentes widget nicht auf null gesetzt');
+		self::assertFalse(isset($formData['texte']['widget-thatDoesNotExistInTheXml1']),'wert für nicht existentes widget nicht auf null gesetzt');
+		self::assertFalse(isset($formData['widget-thatDoesNotExistInTheXml2']),'wert für nicht existentes widget nicht auf null gesetzt');
 	}
 }
 

--- a/tests/api/class.tx_mkforms_tests_api_mainrenderer_testcase.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainrenderer_testcase.php
@@ -101,7 +101,7 @@ class tx_mkforms_tests_api_mainrenderer_testcase extends tx_phpunit_testcase {
 
 		$aRendered = $oRenderer->_render(array());
 
-		$this->assertContains(
+		self::assertContains(
 			'<input type="hidden" name="radioTestForm[MKFORMS_REQUEST_TOKEN]" id="radioTestForm_MKFORMS_REQUEST_TOKEN" value="'.$oForm->getCsrfProtectionToken().'" />',
 			$aRendered['HIDDEN'],
 			'Es ist nicht der richtige request token enthalten!'
@@ -110,8 +110,8 @@ class tx_mkforms_tests_api_mainrenderer_testcase extends tx_phpunit_testcase {
 
 		//requestToken auch in der session?
 		$aSessionData = $GLOBALS['TSFE']->fe_user->getKey('ses', 'mkforms');
-		$this->assertEquals(1,count($aSessionData['requestToken']),'mehr request tokens in der session als erwartet!');
-		$this->assertEquals($aSessionData['requestToken']['radioTestForm'],$oForm->getCsrfProtectionToken(),'falscher request token in der session!');
+		self::assertEquals(1,count($aSessionData['requestToken']),'mehr request tokens in der session als erwartet!');
+		self::assertEquals($aSessionData['requestToken']['radioTestForm'],$oForm->getCsrfProtectionToken(),'falscher request token in der session!');
 	}
 
 	/**
@@ -134,7 +134,7 @@ class tx_mkforms_tests_api_mainrenderer_testcase extends tx_phpunit_testcase {
 
 		$aRendered = $oRenderer->_render(array());
 
-		$this->assertContains(
+		self::assertContains(
 			'<input type="hidden" name="radioTestForm[MKFORMS_REQUEST_TOKEN]" id="radioTestForm_MKFORMS_REQUEST_TOKEN" value="'.$oForm->getCsrfProtectionToken().'" />',
 			$aRendered['HIDDEN'],
 			'Es ist nicht der richtige request token enthalten!'
@@ -143,11 +143,11 @@ class tx_mkforms_tests_api_mainrenderer_testcase extends tx_phpunit_testcase {
 
 		//requestToken auch in der session?
 		$aSessionData = $GLOBALS['TSFE']->fe_user->getKey('ses', 'mkforms');
-		$this->assertEquals(3,count($aSessionData['requestToken']),'mehr request tokens in der session als erwartet!');
-		$this->assertEquals($aSessionData['requestToken']['radioTestForm'],$oForm->getCsrfProtectionToken(),'falscher request token in der session!');
+		self::assertEquals(3,count($aSessionData['requestToken']),'mehr request tokens in der session als erwartet!');
+		self::assertEquals($aSessionData['requestToken']['radioTestForm'],$oForm->getCsrfProtectionToken(),'falscher request token in der session!');
 		//alte request tokens richtig?
-		$this->assertEquals($aSessionData['requestToken']['firstForm'],'secret','falscher request token in der session!');
-		$this->assertEquals($aSessionData['requestToken']['secondForm'],'anotherSecret','falscher request token in der session!');
+		self::assertEquals($aSessionData['requestToken']['firstForm'],'secret','falscher request token in der session!');
+		self::assertEquals($aSessionData['requestToken']['secondForm'],'anotherSecret','falscher request token in der session!');
 
 	}
 }

--- a/tests/api/class.tx_mkforms_tests_api_mainrenderlet_testcase.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainrenderlet_testcase.php
@@ -78,10 +78,10 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 	public function testSetValueSanitizesStringIfConfigured() {
 		//per default soll bereinigt werden
 		$this->oForm->getWidget('widget-text')->setValue('<script>alert("ohoh");</script>');
-		$this->assertEquals('<sc<x>ript>alert("ohoh");</script>',$this->oForm->getWidget('widget-text')->getValue(),'JS wurde nicht entfernt bei widget-text!');
+		self::assertEquals('<sc<x>ript>alert("ohoh");</script>',$this->oForm->getWidget('widget-text')->getValue(),'JS wurde nicht entfernt bei widget-text!');
 		//hier ist sanitize auf false gesetzt
 		$this->oForm->getWidget('widget-text2')->setValue('<script>alert("ohoh");</script>');
-		$this->assertEquals('<script>alert("ohoh");</script>',$this->oForm->getWidget('widget-text2')->getValue(),'JS wurde nicht entfernt bei widget-text2!');
+		self::assertEquals('<script>alert("ohoh");</script>',$this->oForm->getWidget('widget-text2')->getValue(),'JS wurde nicht entfernt bei widget-text2!');
 	}
 
 	/**
@@ -103,7 +103,7 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 		$dUsedtime = microtime(true) -$dTime;
 
 		//der grenzwert sollte nicht überschritten werden
-		$this->assertLessThanOrEqual('0.1200000000000000', $dUsedtime, 'Das bereinigen des Values dauert zu lange und sollte refactorisiert werden.');
+		self::assertLessThanOrEqual('0.1200000000000000', $dUsedtime, 'Das bereinigen des Values dauert zu lange und sollte refactorisiert werden.');
 	}
 
 	/**
@@ -124,7 +124,7 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 		}
 		$dUsedtime = microtime(true) -$dTime;
 		//der grenzwert sollte nicht überschritten werden
-		$this->assertLessThanOrEqual('0.0400000000000000', $dUsedtime, 'Das bereinigen des Values dauert zu lange und sollte refactorisiert werden.');
+		self::assertLessThanOrEqual('0.0400000000000000', $dUsedtime, 'Das bereinigen des Values dauert zu lange und sollte refactorisiert werden.');
 	}
 
 	/**
@@ -133,7 +133,7 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 	public function testGetValueForHtmlConvertsHtmlSpecialCharsCorrectIfIsString() {
 		$mainRenderlet = tx_rnbase::makeInstance('formidable_mainrenderlet');
 
-		$this->assertEquals(
+		self::assertEquals(
 			'&quot;test&quot;',$mainRenderlet->getValueForHtml('"test"'), 'falsche bereinigt'
 		);
 	}
@@ -144,7 +144,7 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 	public function testGetValueForHtmlConvertsCurlyBracketsCorrect() {
 		$mainRenderlet = tx_rnbase::makeInstance('formidable_mainrenderlet');
 
-		$this->assertEquals(
+		self::assertEquals(
 			'&#123;test&#125;',$mainRenderlet->getValueForHtml('{test}'), 'falsche bereinigt'
 		);
 	}
@@ -155,7 +155,7 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 	public function testGetValueForHtmlConvertsNotHtmlSpecialCharsCorrectIfIsArray() {
 		$mainRenderlet = tx_rnbase::makeInstance('formidable_mainrenderlet');
 
-		$this->assertEquals(
+		self::assertEquals(
 			array('test'),$mainRenderlet->getValueForHtml(array('test')), 'array bereinigt'
 		);
 	}
@@ -172,14 +172,14 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 		$placeholderFound = FALSE;
 		foreach ($addInputParams as $addInputParam) {
 			if (strpos($addInputParam, 'placeholder') !== FALSE) {
-				$this->assertEquals(
+				self::assertEquals(
 					'placeholder="Jump to last page"', $addInputParam,
 					'placeholder falsch'
 				);
 				$placeholderFound = TRUE;
 			}
 		}
-		$this->assertTrue($placeholderFound, 'placeholder attribut nicht gefunden');
+		self::assertTrue($placeholderFound, 'placeholder attribut nicht gefunden');
 	}
 
 	/**
@@ -196,7 +196,7 @@ class tx_mkforms_tests_api_mainrenderlet_testcase extends tx_phpunit_testcase {
 				$placeholderFound = TRUE;
 			}
 		}
-		$this->assertFalse($placeholderFound, 'placeholder attribut gefunden');
+		self::assertFalse($placeholderFound, 'placeholder attribut gefunden');
 	}
 }
 

--- a/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php
@@ -76,22 +76,22 @@ class tx_mkforms_tests_api_mainvalidator_testcase extends tx_phpunit_testcase {
 		// UTF-8 Text: 'The € - ä ö ü';
 		$utf8Str = tx_rnbase_util_Strings::hexArr2bin(unserialize('a:18:{i:0;s:2:"54";i:1;s:2:"68";i:2;s:2:"65";i:3;s:2:"20";i:4;s:2:"e2";i:5;s:2:"82";i:6;s:2:"ac";i:7;s:2:"20";i:8;s:2:"2d";i:9;s:2:"20";i:10;s:2:"c3";i:11;s:2:"a4";i:12;s:2:"20";i:13;s:2:"c3";i:14;s:2:"b6";i:15;s:2:"20";i:16;s:2:"c3";i:17;s:2:"bc";}'));
 
-		$this->assertFalse($this->oMainValidator->_isTooLongByChars($utf8Str,14),'Es wurde nicht die korrekte Länge für den UTF-8 String erkannt. Maximale Anzahl: 14; Zeichenlänge:13');
-		$this->assertFalse($this->oMainValidator->_isTooLongByChars($utf8Str,13),'Es wurde nicht die korrekte Länge für den UTF-8 String erkannt. Maximale Anzahl: 13; Zeichenlänge:13');
-		$this->assertTrue($this->oMainValidator->_isTooLongByChars($utf8Str,12),'Es wurde nicht die korrekte Länge für den UTF-8 String erkannt. Maximale Anzahl: 12; Zeichenlänge:13');
+		self::assertFalse($this->oMainValidator->_isTooLongByChars($utf8Str,14),'Es wurde nicht die korrekte Länge für den UTF-8 String erkannt. Maximale Anzahl: 14; Zeichenlänge:13');
+		self::assertFalse($this->oMainValidator->_isTooLongByChars($utf8Str,13),'Es wurde nicht die korrekte Länge für den UTF-8 String erkannt. Maximale Anzahl: 13; Zeichenlänge:13');
+		self::assertTrue($this->oMainValidator->_isTooLongByChars($utf8Str,12),'Es wurde nicht die korrekte Länge für den UTF-8 String erkannt. Maximale Anzahl: 12; Zeichenlänge:13');
 
 		// ISO-Text: 'The EUR - ä ö ü';
 		$iso8Str = tx_rnbase_util_Strings::hexArr2bin(unserialize('a:15:{i:0;s:2:"54";i:1;s:2:"68";i:2;s:2:"65";i:3;s:2:"20";i:4;s:2:"45";i:5;s:2:"55";i:6;s:2:"52";i:7;s:2:"20";i:8;s:2:"2d";i:9;s:2:"20";i:10;s:2:"e4";i:11;s:2:"20";i:12;s:2:"f6";i:13;s:2:"20";i:14;s:2:"fc";}'));
-		$this->assertFalse($this->oMainValidator->_isTooLongByChars($iso8Str,16,'latin1'),'Es wurde nicht die korrekte Länge für den ISO String erkannt. Maximale Anzahl: 16; Zeichenlänge:15');
-		$this->assertFalse($this->oMainValidator->_isTooLongByChars($iso8Str,15,'latin1'),'Es wurde nicht die korrekte Länge für den ISO String erkannt. Maximale Anzahl: 15; Zeichenlänge:15');
-		$this->assertTrue($this->oMainValidator->_isTooLongByChars($iso8Str,14,'latin1'),'Es wurde nicht die korrekte Länge für den ISO String erkannt. Maximale Anzahl: 14; Zeichenlänge:15');
+		self::assertFalse($this->oMainValidator->_isTooLongByChars($iso8Str,16,'latin1'),'Es wurde nicht die korrekte Länge für den ISO String erkannt. Maximale Anzahl: 16; Zeichenlänge:15');
+		self::assertFalse($this->oMainValidator->_isTooLongByChars($iso8Str,15,'latin1'),'Es wurde nicht die korrekte Länge für den ISO String erkannt. Maximale Anzahl: 15; Zeichenlänge:15');
+		self::assertTrue($this->oMainValidator->_isTooLongByChars($iso8Str,14,'latin1'),'Es wurde nicht die korrekte Länge für den ISO String erkannt. Maximale Anzahl: 14; Zeichenlänge:15');
 	}
 
 	/**
 	 *
 	 */
 	public function testOneRdtHasAValueReturnsTrueIfNothingHasAValue(){
-		$this->assertTrue($this->oMainValidator->_oneRdtHasAValue(0,'fieldset__texte__input__widget-text'),'Es wurde nicht false zurück gegeben!');
+		self::assertTrue($this->oMainValidator->_oneRdtHasAValue(0,'fieldset__texte__input__widget-text'),'Es wurde nicht false zurück gegeben!');
 	}
 
 	/**
@@ -99,14 +99,14 @@ class tx_mkforms_tests_api_mainvalidator_testcase extends tx_phpunit_testcase {
 	 */
 	public function testOneRdtHasAValueReturnsFalseIfGivenRdtHasAValueAndSelfNot(){
 		$this->oForm->getWidget('fieldset__texte__input__widget-text')->setValue(1);
-		$this->assertFalse($this->oMainValidator->_oneRdtHasAValue(0,'fieldset__texte__input__widget-text'),'Es wurde nicht true zurück gegeben!');
+		self::assertFalse($this->oMainValidator->_oneRdtHasAValue(0,'fieldset__texte__input__widget-text'),'Es wurde nicht true zurück gegeben!');
 	}
 
 	/**
 	 *
 	 */
 	public function testOneRdtHasAValueReturnsFalseIfSelfHasAValueAndGivenRdtNot(){
-		$this->assertFalse($this->oMainValidator->_oneRdtHasAValue(2,'fieldset__texte__input__widget-text'),'Es wurde nicht true zurück gegeben!');
+		self::assertFalse($this->oMainValidator->_oneRdtHasAValue(2,'fieldset__texte__input__widget-text'),'Es wurde nicht true zurück gegeben!');
 	}
 
 	/**
@@ -114,7 +114,7 @@ class tx_mkforms_tests_api_mainvalidator_testcase extends tx_phpunit_testcase {
 	 */
 	public function testHasThisOrDependentAValueReturnsFalseIfBothHaveAValue(){
 		$this->oForm->getWidget('fieldset__texte__input__widget-text')->setValue(1);
-		$this->assertFalse($this->oMainValidator->_oneRdtHasAValue(2,'fieldset__texte__input__widget-text'),'Es wurde nicht true zurück gegeben!');
+		self::assertFalse($this->oMainValidator->_oneRdtHasAValue(2,'fieldset__texte__input__widget-text'),'Es wurde nicht true zurück gegeben!');
 	}
 
 	public function testCheckDependsOnReturnsTrueWhenDependentWidgetHasValue(){
@@ -131,7 +131,7 @@ class tx_mkforms_tests_api_mainvalidator_testcase extends tx_phpunit_testcase {
 			)
 		);
 
-		$this->assertTrue(
+		self::assertTrue(
 			$method->invoke(
 				$this->oMainValidator,
 				$this->oForm->getWidget('fieldset__widget-radiobutton'),
@@ -155,7 +155,7 @@ class tx_mkforms_tests_api_mainvalidator_testcase extends tx_phpunit_testcase {
 			)
 		);
 
-		$this->assertFalse(
+		self::assertFalse(
 				$method->invoke(
 					$this->oMainValidator,
 					$this->oForm->getWidget('fieldset__widget-radiobutton'),

--- a/tests/api/class.tx_mkforms_tests_api_tx_ameosformidable_testcase.php
+++ b/tests/api/class.tx_mkforms_tests_api_tx_ameosformidable_testcase.php
@@ -121,7 +121,7 @@ class tx_mkforms_tests_api_tx_ameosformidable_testcase extends tx_phpunit_testca
 		$_POST['radioTestForm']['MKFORMS_REQUEST_TOKEN'] = 'iAmInvalid';
 		$oForm = tx_mkforms_tests_Util::getForm(false);
 
-		$this->assertNotContains(
+		self::assertNotContains(
 			'<input type="hidden" name="radioTestForm[MKFORMS_REQUEST_TOKEN]" id="radioTestForm_MKFORMS_REQUEST_TOKEN" value="'.$oForm->getCsrfProtectionToken().'" />',
 			$oForm->render(),
 			'Es ist nicht der richtige request token enthalten!'
@@ -141,7 +141,7 @@ class tx_mkforms_tests_api_tx_ameosformidable_testcase extends tx_phpunit_testca
 		//jetzt die eigentliche initialisierung
 		$oForm = tx_mkforms_tests_Util::getForm();
 
-		$this->assertContains(
+		self::assertContains(
 			'<input type="hidden" name="radioTestForm[MKFORMS_REQUEST_TOKEN]" id="radioTestForm_MKFORMS_REQUEST_TOKEN" value="'.$oForm->getCsrfProtectionToken().'" />',
 			$oForm->render(),
 			'Es ist nicht der richtige request token enthalten!'

--- a/tests/util/class.tx_mkforms_tests_util_Div_testcase.php
+++ b/tests/util/class.tx_mkforms_tests_util_Div_testcase.php
@@ -36,10 +36,10 @@ tx_rnbase::load('tx_mkforms_util_Div');
 class tx_mkforms_tests_util_Div_testcase extends tx_phpunit_testcase {
 
 	public function testToCamelCase() {
-		$this->assertEquals('FeUsers',tx_mkforms_util_Div::toCamelCase('fe_users'));
-		$this->assertEquals('feUsers',tx_mkforms_util_Div::toCamelCase('fe_users', '_', true));
-		$this->assertEquals('TxMklibWordlist',tx_mkforms_util_Div::toCamelCase('tx_mklib_wordlist'));
-		$this->assertEquals('TxMklibTestsUtilStringTestcase',tx_mkforms_util_Div::toCamelCase('tx_mklib_tests_util_String_testcase'));
+		self::assertEquals('FeUsers',tx_mkforms_util_Div::toCamelCase('fe_users'));
+		self::assertEquals('feUsers',tx_mkforms_util_Div::toCamelCase('fe_users', '_', true));
+		self::assertEquals('TxMklibWordlist',tx_mkforms_util_Div::toCamelCase('tx_mklib_wordlist'));
+		self::assertEquals('TxMklibTestsUtilStringTestcase',tx_mkforms_util_Div::toCamelCase('tx_mklib_tests_util_String_testcase'));
 
 	}
 	public function testGetSetupByKeys(){
@@ -78,24 +78,24 @@ class tx_mkforms_tests_util_Div_testcase extends tx_phpunit_testcase {
 				),
 			);
 		$aArray = tx_mkforms_util_Div::getSetupByKeys($aConfig, $aWill);
-		$this->assertTrue(array_key_exists('lib.', $aArray), 'lib. not found in array.');
-		$this->assertTrue(array_key_exists('mkforms.', $aArray['lib.']), 'lib.mkforms. not found in array.');
-		$this->assertTrue(array_key_exists('formbase.', $aArray['lib.']['mkforms.']), 'lib.mkforms.formbase. not found in array.');
-		$this->assertTrue(array_key_exists('testmode', $aArray['lib.']['mkforms.']['formbase.']), 'lib.mkforms.formbase.testmode not found in array.');
-		$this->assertTrue((bool) $aArray['lib.']['mkforms.']['formbase.']['testmode'], 'lib.mkforms.formbase.testmode is not true.');
-		$this->assertTrue(array_key_exists('mkextension.', $aArray['lib.']), 'lib.mkextension. not found in array.');
-		$this->assertTrue(array_key_exists('installed', $aArray['lib.']['mkextension.']), 'lib.mkextension.installed not found in array.');
-		$this->assertTrue((bool) $aArray['lib.']['mkextension.']['installed'], 'lib.mkextension.installed is not true.');
+		self::assertTrue(array_key_exists('lib.', $aArray), 'lib. not found in array.');
+		self::assertTrue(array_key_exists('mkforms.', $aArray['lib.']), 'lib.mkforms. not found in array.');
+		self::assertTrue(array_key_exists('formbase.', $aArray['lib.']['mkforms.']), 'lib.mkforms.formbase. not found in array.');
+		self::assertTrue(array_key_exists('testmode', $aArray['lib.']['mkforms.']['formbase.']), 'lib.mkforms.formbase.testmode not found in array.');
+		self::assertTrue((bool) $aArray['lib.']['mkforms.']['formbase.']['testmode'], 'lib.mkforms.formbase.testmode is not true.');
+		self::assertTrue(array_key_exists('mkextension.', $aArray['lib.']), 'lib.mkextension. not found in array.');
+		self::assertTrue(array_key_exists('installed', $aArray['lib.']['mkextension.']), 'lib.mkextension.installed not found in array.');
+		self::assertTrue((bool) $aArray['lib.']['mkextension.']['installed'], 'lib.mkextension.installed is not true.');
 
-		$this->assertTrue(array_key_exists('plugin.', $aArray), 'plugin. not found in array.');
-		$this->assertTrue(array_key_exists('tx_mkforms', $aArray['plugin.']), 'plugin.tx_mkforms not found in array.');
-		$this->assertEquals('USER_INT', $aArray['plugin.']['tx_mkforms'], 'plugin.tx_mkforms not USER_INT.');
-		$this->assertTrue(array_key_exists('tx_mkforms.', $aArray['plugin.']), 'plugin.tx_mkforms. not found in array.');
-		$this->assertTrue(array_key_exists('genericTemplate', $aArray['plugin.']['tx_mkforms.']), 'plugin.tx_mkforms.genericTemplate not found in array.');
-		$this->assertEquals('EXT:mkforms/templates/formonly.html', $aArray['plugin.']['tx_mkforms.']['genericTemplate'], 'plugin.tx_mkforms.genericTemplate has wrong value.');
+		self::assertTrue(array_key_exists('plugin.', $aArray), 'plugin. not found in array.');
+		self::assertTrue(array_key_exists('tx_mkforms', $aArray['plugin.']), 'plugin.tx_mkforms not found in array.');
+		self::assertEquals('USER_INT', $aArray['plugin.']['tx_mkforms'], 'plugin.tx_mkforms not USER_INT.');
+		self::assertTrue(array_key_exists('tx_mkforms.', $aArray['plugin.']), 'plugin.tx_mkforms. not found in array.');
+		self::assertTrue(array_key_exists('genericTemplate', $aArray['plugin.']['tx_mkforms.']), 'plugin.tx_mkforms.genericTemplate not found in array.');
+		self::assertEquals('EXT:mkforms/templates/formonly.html', $aArray['plugin.']['tx_mkforms.']['genericTemplate'], 'plugin.tx_mkforms.genericTemplate has wrong value.');
 
-		$this->assertFalse(array_key_exists('tx_mkextension.', $aArray['plugin.']), 'plugin.tx_mkextension. found in array.');
-		$this->assertFalse(array_key_exists('config.', $aArray), 'config. found in array.');
+		self::assertFalse(array_key_exists('tx_mkextension.', $aArray['plugin.']), 'plugin.tx_mkextension. found in array.');
+		self::assertFalse(array_key_exists('config.', $aArray), 'config. found in array.');
 	}
 
 	/**
@@ -118,7 +118,7 @@ class tx_mkforms_tests_util_Div_testcase extends tx_phpunit_testcase {
 		}
 
 		$cleanedFile = tx_mkforms_util_Div::cleanupFileName($rawFile);
-		$this->assertEquals($expectedFile, $cleanedFile);
+		self::assertEquals($expectedFile, $cleanedFile);
 	}
 	/**
 	 * DataProvider for cleanupFileName Test.

--- a/tests/util/class.tx_mkforms_tests_util_FormBaseAjax_testcase.php
+++ b/tests/util/class.tx_mkforms_tests_util_FormBaseAjax_testcase.php
@@ -44,13 +44,13 @@ class tx_mkforms_tests_util_FormBaseAjax_testcase extends tx_phpunit_testcase {
 		$ret = tx_mkforms_util_FormBaseAjax::repaintDependencies($params, tx_mkforms_tests_Util::getForm());
 		// formidable_mainrenderlet::majixRepaintDependancies liefert immer ein array!
 		$ret = $ret[0];
-		$this->assertEquals('<input type="checkbox" name="radioTestForm[fieldset][widget-checksingle][checkbox]"'
+		self::assertEquals('<input type="checkbox" name="radioTestForm[fieldset][widget-checksingle][checkbox]"'
 				.' id="radioTestForm__fieldset__widget-checksingle_checkbox"  value="1" /><input type="hidden" '
 				.'name="radioTestForm[fieldset][widget-checksingle]" id="radioTestForm__fieldset__widget-checksingle"  '
 				.'value="0" />', $ret['data'], 'Es wurde nicht die richtige data zurück gegeben!');
-		$this->assertEquals('radioTestForm__fieldset__widget-checksingle',$ret['object'],'Es wurde nicht das richtige object zurück gegeben!');
-		$this->assertEmpty($ret['databag'],'Es wurde doch ein databag zurück gegeben!');
-		$this->assertEquals('repaint',$ret['method'],'Es wurde nicht die richtige Methode zurück gegeben!');
+		self::assertEquals('radioTestForm__fieldset__widget-checksingle',$ret['object'],'Es wurde nicht das richtige object zurück gegeben!');
+		self::assertEmpty($ret['databag'],'Es wurde doch ein databag zurück gegeben!');
+		self::assertEquals('repaint',$ret['method'],'Es wurde nicht die richtige Methode zurück gegeben!');
 	}
 }
 

--- a/tests/util/class.tx_mkforms_tests_util_FormBase_testcase.php
+++ b/tests/util/class.tx_mkforms_tests_util_FormBase_testcase.php
@@ -44,10 +44,10 @@ class tx_mkforms_tests_util_FormBase_testcase extends tx_phpunit_testcase {
 			'tx_mkforms_util_FormBase', array('getRowsFromDataBase')
 		);
 		$form = tx_mkforms_tests_Util::getForm();
-		$formBase::staticExpects($this->once())
+		$formBase::staticExpects(self::once())
 			->method('getRowsFromDataBase')
 			->with(array('someParams'), $form)
-			->will($this->returnValue(
+			->will(self::returnValue(
 				array(
 					0 => array(
 						'__value__' => 123, '__caption__' => 'first'
@@ -58,7 +58,7 @@ class tx_mkforms_tests_util_FormBase_testcase extends tx_phpunit_testcase {
 				)
 			));
 
-		$this->assertEquals(
+		self::assertEquals(
 			array(
 				0 => array('value' => 123, 'caption' => 'first'),
 				1 => array('value' => 456, 'caption' => 'second'),

--- a/tests/util/class.tx_mkforms_tests_util_Json_testcase.php
+++ b/tests/util/class.tx_mkforms_tests_util_Json_testcase.php
@@ -42,7 +42,7 @@ class tx_mkforms_tests_util_Json_testcase extends tx_phpunit_testcase {
 		$string = pack("H*", 'e280a8');
 		$string = 'davor '.$string.' dazwischen'.$string.'dahinter';
 		$json = $this->getNewInstance()->encode($string);
-		$this->assertEquals('"davor \n dazwischen\ndahinter"', $json);
+		self::assertEquals('"davor \n dazwischen\ndahinter"', $json);
 	}
 }
 

--- a/tests/util/class.tx_mkforms_tests_util_Templates_testcase.php
+++ b/tests/util/class.tx_mkforms_tests_util_Templates_testcase.php
@@ -38,7 +38,7 @@ class tx_mkforms_tests_util_Templates_testcase extends tx_phpunit_testcase {
 	 * @group unit
 	 */
 	public function testSanitizeStringForTemplateEngine() {
-		$this->assertEquals(
+		self::assertEquals(
 			'&#123;test&#125;',
 			tx_mkforms_util_Templates::sanitizeStringForTemplateEngine('{test}'),
 			'string falsch bereinigt'

--- a/tests/widgets/class.tx_mkforms_tests_widgets_fluidviewhelper_testcase.php
+++ b/tests/widgets/class.tx_mkforms_tests_widgets_fluidviewhelper_testcase.php
@@ -59,10 +59,10 @@ class tx_mkforms_tests_widgets_fluidviewhelper_testcase
 
 		$parsedParams = $this->callInaccessibleMethod($widget, 'getArguments');
 
-		$this->assertCount(3, $parsedParams);
-		$this->assertEquals('DebugTitle', $parsedParams['title']);
-		$this->assertEquals(4, $parsedParams['maxDepth']);
-		$this->assertEquals('Hello World', $parsedParams['plainText']);
+		self::assertCount(3, $parsedParams);
+		self::assertEquals('DebugTitle', $parsedParams['title']);
+		self::assertEquals(4, $parsedParams['maxDepth']);
+		self::assertEquals('Hello World', $parsedParams['plainText']);
 	}
 
 	/**
@@ -80,36 +80,36 @@ class tx_mkforms_tests_widgets_fluidviewhelper_testcase
 		);
 
 		$helper
-			->expects($this->once())
+			->expects(self::once())
 			->method('initializeArgumentsAndRender')
 			->with()
-			->will($this->returnValue('DEBUGCONTENT'))
+			->will(self::returnValue('DEBUGCONTENT'))
 		;
 		$widget
-			->expects($this->once())
+			->expects(self::once())
 			->method('getViewHelper')
 			->with()
-			->will($this->returnValue($helper))
+			->will(self::returnValue($helper))
 		;
 		$widget
-			->expects($this->once())
+			->expects(self::once())
 			->method('getLabel')
 			->with()
-			->will($this->returnValue('LABEL:'))
+			->will(self::returnValue('LABEL:'))
 		;
 		$widget
-			->expects($this->once())
+			->expects(self::once())
 			->method('_displayLabel')
 			->with()
 			->will($this->returnArgument(0))
 		;
 		$htmlBag = $this->callInaccessibleMethod($widget, '_render');
 
-		$this->assertCount(4, $htmlBag);
-		$this->assertEquals('LABEL:DEBUGCONTENT', $htmlBag['__compiled']);
-		$this->assertEquals('DEBUGCONTENT', $htmlBag['rendered']);
-		$this->assertEquals('LABEL:', $htmlBag['label']);
-		$this->assertEquals('DebugTitle', $htmlBag['value']);
+		self::assertCount(4, $htmlBag);
+		self::assertEquals('LABEL:DEBUGCONTENT', $htmlBag['__compiled']);
+		self::assertEquals('DEBUGCONTENT', $htmlBag['rendered']);
+		self::assertEquals('LABEL:', $htmlBag['label']);
+		self::assertEquals('DebugTitle', $htmlBag['value']);
 	}
 
 	/**
@@ -127,34 +127,34 @@ class tx_mkforms_tests_widgets_fluidviewhelper_testcase
 		);
 
 		$helper
-			->expects($this->once())
+			->expects(self::once())
 			->method('initializeArgumentsAndRender')
 			->with()
 			->will($this->throwException(new Exception('PHPUnitException', 5050)))
 		;
 		$widget
-			->expects($this->once())
+			->expects(self::once())
 			->method('getViewHelper')
 			->with()
-			->will($this->returnValue($helper))
+			->will(self::returnValue($helper))
 		;
 		$widget
-			->expects($this->once())
+			->expects(self::once())
 			->method('getLabel')
 			->with()
-			->will($this->returnValue(''))
+			->will(self::returnValue(''))
 		;
 		$htmlBag = $this->callInaccessibleMethod($widget, '_render');
 
-		$this->assertCount(6, $htmlBag);
-		$this->assertEquals('<span class="error">PHPUnitException</span>', $htmlBag['__compiled']);
-		$this->assertEquals('<span class="error">PHPUnitException</span>', $htmlBag['rendered']);
-		$this->assertEquals('', $htmlBag['label']);
-		$this->assertEquals('DebugTitle', $htmlBag['value']);
-		$this->assertEquals(TRUE, $htmlBag['renderError']);
-		$this->assertEquals(TRUE, is_array($htmlBag['renderError.']));
-		$this->assertEquals(5050, $htmlBag['renderError.']['code']);
-		$this->assertEquals('PHPUnitException', $htmlBag['renderError.']['message']);
+		self::assertCount(6, $htmlBag);
+		self::assertEquals('<span class="error">PHPUnitException</span>', $htmlBag['__compiled']);
+		self::assertEquals('<span class="error">PHPUnitException</span>', $htmlBag['rendered']);
+		self::assertEquals('', $htmlBag['label']);
+		self::assertEquals('DebugTitle', $htmlBag['value']);
+		self::assertEquals(TRUE, $htmlBag['renderError']);
+		self::assertEquals(TRUE, is_array($htmlBag['renderError.']));
+		self::assertEquals(5050, $htmlBag['renderError.']['code']);
+		self::assertEquals('PHPUnitException', $htmlBag['renderError.']['message']);
 	}
 
 	/**
@@ -178,17 +178,17 @@ class tx_mkforms_tests_widgets_fluidviewhelper_testcase
 			array_keys($mockedMethods)
 		);
 		$widget
-			->expects($this->any())
+			->expects(self::any())
 			->method('getValue')
 			->with()
-			->will($this->returnValue('DebugTitle'))
+			->will(self::returnValue('DebugTitle'))
 		;
 		$widget
-			->expects($this->any())
+			->expects(self::any())
 			->method('getParams')
 			->with()
 			->will(
-				$this->returnValue(
+				self::returnValue(
 					array(
 						'title' => 'rdt:value',
 						'maxDepth' => 4,

--- a/tests/widgets/class.tx_mkforms_tests_widgets_text_Main_testcase.php
+++ b/tests/widgets/class.tx_mkforms_tests_widgets_text_Main_testcase.php
@@ -55,14 +55,14 @@ class tx_mkforms_tests_widgets_text_Main_testcase
 	public function testRenderSetsDefaultTypeIfNoInputTypeIsConfigured() {
 		$widget = $this->getWidgetMock(array('_render', 'getInputType'));
 
-		$widget->expects($this->once())
+		$widget->expects(self::once())
 			->method('_navConf')
 			->with('/inputtype')
-			->will($this->returnValue(''));
+			->will(self::returnValue(''));
 
 		$htmlBag = $this->callInaccessibleMethod($widget, '_render');
 
-		$this->assertEquals(
+		self::assertEquals(
 			'<input type="text" name="" id="" value=""  />',
 			$htmlBag['input']
 		);
@@ -74,14 +74,14 @@ class tx_mkforms_tests_widgets_text_Main_testcase
 	public function testRenderSetsConfiguredInputType() {
 		$widget = $this->getWidgetMock(array('_render', 'getInputType'));
 
-		$widget->expects($this->once())
+		$widget->expects(self::once())
 			->method('_navConf')
 			->with('/inputtype')
-			->will($this->returnValue('email'));
+			->will(self::returnValue('email'));
 
 		$htmlBag = $this->callInaccessibleMethod($widget, '_render');
 
-		$this->assertEquals(
+		self::assertEquals(
 			'<input type="email" name="" id="" value=""  />',
 			$htmlBag['input']
 		);
@@ -108,10 +108,10 @@ class tx_mkforms_tests_widgets_text_Main_testcase
 			array_keys($mockedMethods)
 		);
 		$widget
-			->expects($this->any())
+			->expects(self::any())
 			->method('getValue')
 			->with()
-			->will($this->returnValue('DebugTitle'))
+			->will(self::returnValue('DebugTitle'))
 		;
 
 		return $widget;


### PR DESCRIPTION
This commit changes the calls to static PHPUnit methods to static calls,
thus reducing warnings.