### PR TITLE
[CLEANUP] Use more semantic PHPUnit methods

### DIFF
--- a/tests/action/class.tx_mkforms_tests_action_FormBase_testcase.php
+++ b/tests/action/class.tx_mkforms_tests_action_FormBase_testcase.php
@@ -211,22 +211,22 @@ class tx_mkforms_tests_action_FormBase_testcase extends tx_rnbase_tests_BaseTest
         self::assertTrue(isset($formData['submitmode']), 'LINE:'.__LINE__);
         self::assertEquals($formData['submitmode'], 'full', 'LINE:'.__LINE__);
 
-        self::assertTrue(is_array($formData['widget']), 'LINE:'.__LINE__);
+        self::assertInternalType('array', $formData['widget'], 'LINE:' . __LINE__);
         self::assertTrue(isset($formData['widget']['text']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget']['text'], 'Eins', 'LINE:'.__LINE__);
         self::assertTrue(isset($formData['widget']['radiobutton']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget']['radiobutton'], '3', 'LINE:'.__LINE__);
         self::assertTrue(isset($formData['widget']['listbox']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget']['listbox'], '7', 'LINE:'.__LINE__);
-        self::assertTrue(is_array($formData['widget']['checkbox']), 'LINE:'.__LINE__);
+        self::assertInternalType('array', $formData['widget']['checkbox'], 'LINE:' . __LINE__);
         self::assertTrue(isset($formData['widget']['checkbox']['5']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget']['checkbox']['5'], '6', 'LINE:'.__LINE__);
         self::assertTrue(isset($formData['widget']['checkbox']['8']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget']['checkbox']['8'], '9', 'LINE:'.__LINE__);
-        self::assertTrue(is_array($formData['widget1']), 'LINE:'.__LINE__);
+        self::assertInternalType('array', $formData['widget1'], 'LINE:' . __LINE__);
         self::assertTrue(isset($formData['widget1']['text']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget1']['text'], 'Zwei', 'LINE:'.__LINE__);
-        self::assertTrue(is_array($formData['widget2']), 'LINE:'.__LINE__);
+        self::assertInternalType('array', $formData['widget2'], 'LINE:' . __LINE__);
         self::assertTrue(isset($formData['widget2']['text']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget2']['text'], 'Zwei', 'LINE:'.__LINE__);
         self::assertTrue(isset($formData['textarea']), 'LINE:'.__LINE__);
@@ -235,7 +235,7 @@ class tx_mkforms_tests_action_FormBase_testcase extends tx_rnbase_tests_BaseTest
         self::assertEquals($formData['widgetlister']['selected'], '5', 'LINE:'.__LINE__);
         self::assertFalse(isset($formData['widgetlister']['notInXml']), 'LINE:'.__LINE__);
         for ($i = 1; $i <= 5; $i++) {
-            self::assertTrue(is_array($formData['widgetlister'][$i]['listerdata']), $i.' LINE:'.__LINE__);
+            self::assertInternalType('array', $formData['widgetlister'][$i]['listerdata'], $i . ' LINE:' . __LINE__);
             self::assertTrue(isset($formData['widgetlister'][$i]['listerdata']['uid']), $i.' LINE:'.__LINE__);
             self::assertEquals($formData['widgetlister'][$i]['listerdata']['uid'], $i, $i.' LINE:'.__LINE__);
             self::assertTrue(isset($formData['widgetlister'][$i]['listerdata']['title']), $i.' LINE:'.__LINE__);
@@ -252,7 +252,7 @@ class tx_mkforms_tests_action_FormBase_testcase extends tx_rnbase_tests_BaseTest
         self::assertTrue(isset($formData['widget']['date_mysql']), 'LINE:'.__LINE__);
         self::assertEquals($formData['widget']['date_mysql'], '1983-07-05', 'LINE:'.__LINE__);
         //addpostvars
-        self::assertTrue(is_array($formData['addpostvars']), 'LINE:'.__LINE__);
+        self::assertInternalType('array', $formData['addpostvars'], 'LINE:' . __LINE__);
         self::assertEquals($formData['addpostvars'][0]['action'], 'formData', 'LINE:'.__LINE__);
         self::assertTrue(isset($formData['addpostvars'][0]['params']['widget']['submit']), 'LINE:'.__LINE__);
         //addfields
@@ -268,7 +268,7 @@ class tx_mkforms_tests_action_FormBase_testcase extends tx_rnbase_tests_BaseTest
     {
         $action = self::getAction();
 
-        self::assertEquals('tx_mkforms_action_FormBase', get_class($action), 'Wrong class given.');
+        self::assertInstanceOf('\\tx_mkforms_action_FormBase', $action, 'Wrong class given.');
     }
 
     /**

--- a/tests/api/class.tx_mkforms_tests_api_mainrenderer_testcase.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainrenderer_testcase.php
@@ -91,7 +91,7 @@ class tx_mkforms_tests_api_mainrenderer_testcase extends tx_rnbase_tests_BaseTes
 
         //requestToken auch in der session?
         $sessionData = $GLOBALS['TSFE']->fe_user->getKey('ses', 'mkforms');
-        self::assertEquals(1, count($sessionData['requestToken']), 'mehr request tokens in der session als erwartet!');
+        self::assertCount(1, $sessionData['requestToken'], 'mehr request tokens in der session als erwartet!');
         self::assertEquals($sessionData['requestToken']['radioTestForm'], $form->generateRequestToken(), 'falscher request token in der session!');
     }
 
@@ -127,7 +127,7 @@ class tx_mkforms_tests_api_mainrenderer_testcase extends tx_rnbase_tests_BaseTes
 
         //requestToken auch in der session?
         $sessionData = $GLOBALS['TSFE']->fe_user->getKey('ses', 'mkforms');
-        self::assertEquals(3, count($sessionData['requestToken']), 'mehr request tokens in der session als erwartet!');
+        self::assertCount(3, $sessionData['requestToken'], 'mehr request tokens in der session als erwartet!');
         self::assertEquals($sessionData['requestToken']['radioTestForm'], $form->generateRequestToken(), 'falscher request token in der session!');
         //alte request tokens richtig?
         self::assertEquals($sessionData['requestToken']['firstForm'], 'secret', 'falscher request token in der session!');

--- a/tests/util/class.tx_mkforms_tests_util_Div_testcase.php
+++ b/tests/util/class.tx_mkforms_tests_util_Div_testcase.php
@@ -106,7 +106,6 @@ class tx_mkforms_tests_util_Div_testcase extends tx_rnbase_tests_BaseTestCase
      * @param string $iconv
      *
      * @group unit
-     * @test
      * @dataProvider providerCleanupFileName
      */
     public function testCleanupFileName($rawFile, $expectedFile, $usesIconv = false)

--- a/tests/validator/timetracking/class.tx_mkforms_tests_validator_timetracking_Main_testcase.php
+++ b/tests/validator/timetracking/class.tx_mkforms_tests_validator_timetracking_Main_testcase.php
@@ -300,9 +300,7 @@ class tx_mkforms_tests_validator_timetracking_Main_testcase extends tx_rnbase_te
         $validator->handleAfterRenderCheckPoint();
 
         $sessionData = $GLOBALS['TSFE']->fe_user->getKey('ses', 'mkforms');
-        self::assertEquals(
-            1,
-            count($sessionData['creationTimestamp']),
+        self::assertCount(1, $sessionData['creationTimestamp'],
             'der timestamp für die Erstellung des Formulars nicht in der Session'
         );
         self::assertEquals(
@@ -339,9 +337,7 @@ class tx_mkforms_tests_validator_timetracking_Main_testcase extends tx_rnbase_te
         $validator->handleAfterRenderCheckPoint();
 
         $sessionData = $GLOBALS['TSFE']->fe_user->getKey('ses', 'mkforms');
-        self::assertEquals(
-            3,
-            count($sessionData['creationTimestamp']),
+        self::assertCount(3, $sessionData['creationTimestamp'],
             'der timestamp für die Erstellung des Formulars nicht in der Session'
         );
         self::assertEquals(


### PR DESCRIPTION
Also drop one superfluous `@test` annotation.