### PR TITLE
[CLEANUP] Drop unnecessary methods

### DIFF
--- a/action/class.tx_mkforms_action_FormBase.php
+++ b/action/class.tx_mkforms_action_FormBase.php
@@ -399,16 +399,6 @@ class tx_mkforms_action_FormBase extends tx_rnbase_action_BaseIOC
     }
 
     /**
-     * Returns the parameters of the action to use in form
-     *
-     * @return    tx_rnbase_parameters
-     */
-    public function getParameters()
-    {
-        return $this->getConfigurations()->getParameters();
-    }
-
-    /**
      * Returns the config of the action to use in form
      *
      * @return    tx_ameosformidable

--- a/api/class.maindatasource.php
+++ b/api/class.maindatasource.php
@@ -4,11 +4,6 @@ abstract class formidable_maindatasource extends formidable_mainobject
 {
     public $aODataSets = array();
 
-    public function _init(&$oForm, $aElement, $aObjectType, $sXPath, $sNamePrefix = false)
-    {
-        parent::_init($oForm, $aElement, $aObjectType, $sXPath, $sNamePrefix);
-    }
-
     public function _getRecordWindow($iPage, $iRowsPerPage, $bMax = false)
     {
         // page should never be negative

--- a/ds/db/class.tx_mkforms_ds_db_Main.php
+++ b/ds/db/class.tx_mkforms_ds_db_Main.php
@@ -392,11 +392,6 @@ class tx_mkforms_ds_db_Main extends formidable_maindatasource
         die('dsdb:dset_getSignature() disabled');
     }
 
-    public function dset_setCellValue($sSignature, $sPath, $mValue, $sAbsName = false)
-    {
-        $this->aODataSets[$sSignature]->setCellValue($sPath, $mValue);
-    }
-
     public function dset_hasFlexibleStructure()
     {
         // FALSE as structure may not expand / is not flexible (unlike a flexform)

--- a/widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
+++ b/widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
@@ -665,7 +665,7 @@ class tx_mkforms_widgets_mediaupload_Main extends formidable_mainrenderlet
      */
     public function getForm()
     {
-        return $this->oForm;
+        return parent::getForm();
     }
 
     /**


### PR DESCRIPTION
The following kind of methods get dropped/changed:

- methods that are exist as copies of the same method in a parent class
- useless proxy methods