### PR TITLE
[TASK] change composer.json for TYPO3 subtree split

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "typo3-ter/mkforms": "self.version"
     },
     "require": {
-        "typo3/cms-core": "^7.6 || ^8.7",
+        "typo3/cms-core": "^6.2 || ^7.6 || ^8.7",
         "digedag/rn-base": ">=1.4",
         "php": ">=5.4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "typo3-ter/mkforms": "self.version"
     },
     "require": {
-        "typo3/cms": "~6.2 || ~7.6 || ~8.7",
+        "typo3/cms-core": "^7.6 || ^8.7",
         "digedag/rn-base": ">=1.4",
         "php": ">=5.4.0"
     },


### PR DESCRIPTION
For `composer.json` one should require `typo3/cms-core` instead of `typo3/cms`due to the subtree split. In summary the main reason is extensions define a dependency on TYPO3 itself (core) instead of each and every system extension. Details: https://usetypo3.com/typo3-subtree-split-and-composer.html
However this needs to drop v6 support as well. This is one step for v9 compatibility, however even with v8 extensions requiring `typo3/cms` are a hassle to maintain.