### PR TITLE
[BUGFIX] Harden substring searches

### DIFF
--- a/api/class.mainrenderer.php
+++ b/api/class.mainrenderer.php
@@ -442,7 +442,7 @@ TEMPLATE;
                     $aParams[] = 'rowInput::' . $sAs . '::' . $this->getForm()->getWidget($sParam)->_getElementHtmlId();
                 } elseif ($sParam === '$this') {
                     $aParams[] = 'rowInput::this::' . $oRdt->getAbsName();
-                } elseif (strstr($sParam, AMEOSFORMIDABLE_NESTED_SEPARATOR_BEGIN . '*')) {
+                } elseif (strstr($sParam, AMEOSFORMIDABLE_NESTED_SEPARATOR_BEGIN . '*') !== false) {
                     // Shortcut um alle Werte einer Box übergeben
                     // Wir benötigen alle Renderlets mit einem bestimmten Prefix
                     $names = tx_mkforms_util_Div::findKeysWithPrefix(
@@ -466,7 +466,7 @@ TEMPLATE;
                             );
                         }
                     }
-                } elseif (strstr($sParam, '::')) {
+                } elseif (strstr($sParam, '::') !== false) {
                     // Ein freier Parameter
                     $aParams[] = $sParam;
                 } else {

--- a/res/shared/php/pclzip/pclzip.lib.php
+++ b/res/shared/php/pclzip/pclzip.lib.php
@@ -3710,7 +3710,7 @@ class PclZip
             else {
                 if ((($p_entry['external'] & 0x00000010) == 0x00000010) || (substr($p_entry['filename'], -1) == '/')) {
                     $v_dir_to_check = $p_entry['filename'];
-                } elseif (!strstr($p_entry['filename'], '/')) {
+                } elseif (strstr($p_entry['filename'], '/') === false) {
                     $v_dir_to_check = '';
                 } else {
                     $v_dir_to_check = dirname($p_entry['filename']);
@@ -5637,7 +5637,7 @@ function PclZipUtilOptionText($p_option)
   // --------------------------------------------------------------------------------
 function PclZipUtilTranslateWinPath($p_path, $p_remove_disk_letter = true)
 {
-    if (stristr(php_uname(), 'windows')) {
+    if (stristr(php_uname(), 'windows') !== false) {
         // ----- Look for potential disk letter
         if (($p_remove_disk_letter) && (($v_position = strpos($p_path, ':')) != false)) {
             $p_path = substr($p_path, $v_position + 1);

--- a/util/class.tx_mkforms_util_Config.php
+++ b/util/class.tx_mkforms_util_Config.php
@@ -798,7 +798,7 @@ class tx_mkforms_util_Config
 
         $sPath = tx_mkforms_util_Div::trimSlashes(strtolower(substr($sPath, 6)));
 
-        if (!strpos($sPath, '[')) {
+        if (strpos($sPath, '[') === false) {
             return $this->get($sPath, $aConf);
         }
 


### PR DESCRIPTION
For substring searches, a comparison with `false` should always be used to
avoid cases of `0` being interpreted as a non-match.