### PR TITLE
[BUGFIX] Fix autoloading for datasources in non-Composer installation

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -50,7 +50,9 @@ $EM_CONF[$_EXTKEY] = array(
         'classmap' => array(
             'action/',
             'api/',
+            'Classes/',
             'dh/',
+            'ds/',
             'exception/',
             'forms/',
             'hooks/',


### PR DESCRIPTION
Now the autoloader classmap in `ext_emconf.php` is synchronized with the
one in `composer.json` again.