### PR TITLE
[TASK] Add a PHP version constraint to the `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "typo3-ter/mkforms": "self.version"
     },
     "require": {
+        "php": ">=5.6.0",
         "typo3/cms-core": "^7.6 || ^8.7 || ^9.5",
         "digedag/rn-base": "^1.10.5"
     },


### PR DESCRIPTION
The PHP version constraint in the `composer.json` matches the one
in the `ext_emconf.php`.