### PR TITLE
[TASK] Add an `.editorconfig` file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,53 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# JS files
+[*.js]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = tab
+
+# package.json
+[package.json]
+indent_size = 2
+
+# ReST files
+[*.rst]
+indent_size = 3
+max_line_length = 80
+
+# SQL files
+[*.sql]
+indent_style = tab
+indent_size = 2
+
+# TypoScript files
+[*.{typoscript,tsconfig}]
+indent_size = 2
+
+# YAML files
+[{*.yml,*.yaml}]
+indent_size = 2
+
+# XLF files
+[*.xlf]
+indent_style = tab
+
+# .htaccess
+[.htaccess]
+indent_style = tab
+
+# Markdown files
+[*.md]
+max_line_length = 80


### PR DESCRIPTION
This file provides some basic code formatting configuration that
IDEs like PhpStorm can pick up.

The settings in the file reflect what the TYPO3 Core uses in its
`.editorconfig` or in its code.