### PR TITLE
[CLEANUP] Drop XCLASS footers

### DIFF
--- a/action/class.tx_mkforms_action_FormBase.php
+++ b/action/class.tx_mkforms_action_FormBase.php
@@ -438,9 +438,3 @@ class tx_mkforms_action_FormBase extends tx_rnbase_action_BaseIOC
         return 'generic';
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/class.tx_mkforms_action_FormBase.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/class.tx_mkforms_action_FormBase.php'];
-}

--- a/action/redirect/class.tx_mkforms_action_redirect_Main.php
+++ b/action/redirect/class.tx_mkforms_action_redirect_Main.php
@@ -39,9 +39,3 @@ class tx_mkforms_action_redirect_Main extends formidable_mainactionlet
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/redirect/class.tx_mkforms_action_redirect_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/redirect/class.tx_mkforms_action_redirect_Main.php'];
-}

--- a/action/stepper/class.tx_mkforms_action_stepper_Main.php
+++ b/action/stepper/class.tx_mkforms_action_stepper_Main.php
@@ -79,9 +79,3 @@ class tx_mkforms_action_stepper_Main extends formidable_mainactionlet
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/stepper/class.tx_mkforms_action_stepper_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/stepper/class.tx_mkforms_action_stepper_Main.php'];
-}

--- a/action/userobj/class.tx_mkforms_action_userobj_Main.php
+++ b/action/userobj/class.tx_mkforms_action_userobj_Main.php
@@ -14,9 +14,3 @@ class tx_mkforms_action_userobj_Main extends formidable_mainactionlet
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/userobj/api/class.tx_mkforms_action_userobj_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/action/userobj/class.tx_mkforms_action_userobj_Main.php'];
-}

--- a/api/class.mainactionlet.php
+++ b/api/class.mainactionlet.php
@@ -30,9 +30,3 @@ class formidable_mainactionlet extends formidable_mainobject
         return true;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainactionlet.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainactionlet.php'];
-}

--- a/api/class.maindatahandler.php
+++ b/api/class.maindatahandler.php
@@ -1012,9 +1012,3 @@ class formidable_maindatahandler extends formidable_mainobject
         return '';
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.maindatahandler.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.maindatahandler.php'];
-}

--- a/api/class.maindatasource.php
+++ b/api/class.maindatasource.php
@@ -225,7 +225,3 @@ abstract class formidable_maindatasource extends formidable_mainobject
         return $this->_fetchData($aConfig, $aFilters);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/api/class.maindatasource.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/api/class.maindatasource.php'];
-}

--- a/api/class.mainobject.php
+++ b/api/class.mainobject.php
@@ -265,7 +265,3 @@ class formidable_mainobject
         return $this->aObjectType['CLASS'];
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/api/class.mainobject.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/api/class.mainobject.php'];
-}

--- a/api/class.mainrenderer.php
+++ b/api/class.mainrenderer.php
@@ -832,9 +832,3 @@ TEMPLATE;
         return $errorMessages;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainrenderer.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainrenderer.php'];
-}

--- a/api/class.mainrenderlet.php
+++ b/api/class.mainrenderlet.php
@@ -4491,9 +4491,3 @@ JAVASCRIPT;
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainrenderlet.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainrenderlet.php'];
-}

--- a/api/class.mainvalidator.php
+++ b/api/class.mainvalidator.php
@@ -594,9 +594,3 @@ class formidable_mainvalidator extends formidable_mainobject
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainvalidator.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.mainvalidator.php'];
-}

--- a/api/class.tx_ameosformidable.php
+++ b/api/class.tx_ameosformidable.php
@@ -5317,9 +5317,3 @@ JAVASCRIPT;
         return $this;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.tx_ameosformidable.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.tx_ameosformidable.php'];
-}

--- a/api/class.tx_ameosformidable_pi.php
+++ b/api/class.tx_ameosformidable_pi.php
@@ -82,9 +82,3 @@ class tx_ameosformidable_pi extends Tx_Rnbase_Frontend_Plugin
         return $this->pi_wrapInBaseClass($this->oForm->render());
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.tx_ameosformidable_pi.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.tx_ameosformidable_pi.php'];
-}

--- a/api/class.user_ameosformidable_cobj.php
+++ b/api/class.user_ameosformidable_cobj.php
@@ -73,9 +73,3 @@ class user_ameosformidable_cobj
         return $this->oForm->render();
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/api/class.user_ameosformidable_cobj.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/api/class.user_ameosformidable_cobj.php'];
-}

--- a/api/class.user_ameosformidable_userfuncs.php
+++ b/api/class.user_ameosformidable_userfuncs.php
@@ -17,9 +17,3 @@ class user_ameosformidable_userfuncs
         return implode('', $aRes);
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.user_ameosformidable_userfuncs.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/class.user_ameosformidable_userfuncs.php'];
-}

--- a/dh/db/class.tx_mkforms_dh_db_Main.php
+++ b/dh/db/class.tx_mkforms_dh_db_Main.php
@@ -561,9 +561,3 @@ class tx_mkforms_dh_db_Main extends formidable_maindatahandler
         return $this->_isTrue('/fillstandardtypo3fields');
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_db/api/class.tx_dhdb.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_db/api/class.tx_dhdb.php'];
-}

--- a/dh/dbmm/class.tx_mkforms_dh_dbmm_Main.php
+++ b/dh/dbmm/class.tx_mkforms_dh_dbmm_Main.php
@@ -288,9 +288,3 @@ class tx_mkforms_dh_dbmm_Main extends tx_mkforms_dh_db_Main
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_dbmm/api/class.tx_dhdbmm.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_dbmm/api/class.tx_dhdbmm.php'];
-}

--- a/dh/mail/class.tx_mkforms_dh_mail_Main.php
+++ b/dh/mail/class.tx_mkforms_dh_mail_Main.php
@@ -431,9 +431,3 @@ class tx_mkforms_dh_mail_Main extends formidable_maindatahandler
         return $content;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['/mkforms/dh/mail/class.tx_mkforms_dh_mail_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['/mkforms/dh/mail/class.tx_mkforms_dh_mail_Main.php'];
-}

--- a/dh/raw/class.tx_mkforms_dh_raw_Main.php
+++ b/dh/raw/class.tx_mkforms_dh_raw_Main.php
@@ -179,9 +179,3 @@ class tx_mkforms_dh_raw_Main extends formidable_maindatahandler
         return $this->editionMode;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/dh/raw/class.tx_mkforms_dh_raw_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/dh/raw/class.tx_mkforms_dh_raw_Main.php'];
-}

--- a/dh/std/class.tx_mkforms_dh_std_Main.php
+++ b/dh/std/class.tx_mkforms_dh_std_Main.php
@@ -19,9 +19,3 @@ class tx_mkforms_dh_std_Main extends formidable_maindatahandler
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_std/api/class.tx_dhstd.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_std/api/class.tx_dhstd.php'];
-}

--- a/dh/void/class.tx_mkforms_dh_void_Main.php
+++ b/dh/void/class.tx_mkforms_dh_void_Main.php
@@ -14,9 +14,3 @@ class tx_mkforms_dh_void_Main extends formidable_maindatahandler
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_void/api/class.tx_dhvoid.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/dh_void/api/class.tx_dhvoid.php'];
-}

--- a/ds/contentrepository/class.tx_mkforms_ds_contentrepository_Main.php
+++ b/ds/contentrepository/class.tx_mkforms_ds_contentrepository_Main.php
@@ -202,9 +202,3 @@ class tx_mkforms_ds_contentrepository_Main extends formidable_maindatasource
         return $this->oRepo->findOneByUid($sKey);
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/contentrepository/class.tx_mkforms_ds_contentrepository_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/contentrepository/class.tx_mkforms_ds_contentrepository_Main.php'];
-}

--- a/ds/db/class.tx_mkforms_ds_db_Main.php
+++ b/ds/db/class.tx_mkforms_ds_db_Main.php
@@ -490,9 +490,3 @@ class tx_mkforms_ds_db_Main extends formidable_maindatasource
         return '';
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/db/class.tx_mkforms_ds_db_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/db/class.tx_mkforms_ds_db_Main.php'];
-}

--- a/ds/php/class.tx_mkforms_ds_php_Main.php
+++ b/ds/php/class.tx_mkforms_ds_php_Main.php
@@ -109,9 +109,3 @@ class tx_mkforms_ds_php_Main extends formidable_maindatasource
         return true;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/php/class.tx_mkforms_ds_php_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/php/class.tx_mkforms_ds_php_Main.php'];
-}

--- a/ds/phparray/class.tx_mkforms_ds_phparray_Main.php
+++ b/ds/phparray/class.tx_mkforms_ds_phparray_Main.php
@@ -116,9 +116,3 @@ class tx_mkforms_ds_phparray_Main extends formidable_maindatasource
         return false;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/phparray/class.tx_mkforms_ds_phparray_Main.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/ds/phparray/class.tx_mkforms_ds_phparray_Main.php'];
-}

--- a/exception/class.tx_mkforms_exception_Base.php
+++ b/exception/class.tx_mkforms_exception_Base.php
@@ -28,9 +28,3 @@
 class tx_mkforms_exception_Base extends Tx_Rnbase_Exception_Base
 {
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/exception/class.tx_mkforms_exception_Base.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/exception/class.tx_mkforms_exception_Base.php'];
-}

--- a/exception/class.tx_mkforms_exception_DataSourceNotFound.php
+++ b/exception/class.tx_mkforms_exception_DataSourceNotFound.php
@@ -28,9 +28,3 @@
 class tx_mkforms_exception_DataSourceNotFound extends tx_mkforms_exception_Base
 {
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/exception/class.tx_mkforms_exception_DataSourceNotFound.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/exception/class.tx_mkforms_exception_DataSourceNotFound.php'];
-}

--- a/exception/class.tx_mkforms_exception_Mayday.php
+++ b/exception/class.tx_mkforms_exception_Mayday.php
@@ -22,9 +22,3 @@ class tx_mkforms_exception_Mayday extends tx_rnbase_util_Exception
         return htmlspecialchars($stack);
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/exception/class.tx_mkforms_exception_Mayday.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/exception/class.tx_mkforms_exception_Mayday.php'];
-}

--- a/forms/class.tx_mkforms_forms_Base.php
+++ b/forms/class.tx_mkforms_forms_Base.php
@@ -30,9 +30,3 @@ require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.tx_ameosfo
 class tx_mkforms_forms_Base extends tx_ameosformidable
 {
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_Base.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_Base.php'];
-}

--- a/forms/class.tx_mkforms_forms_Factory.php
+++ b/forms/class.tx_mkforms_forms_Factory.php
@@ -39,9 +39,3 @@ class tx_mkforms_forms_Factory
         return tx_rnbase::makeInstance('tx_mkforms_forms_Base', $name);
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_Factory.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_Factory.php'];
-}

--- a/forms/class.tx_mkforms_forms_IForm.php
+++ b/forms/class.tx_mkforms_forms_IForm.php
@@ -68,9 +68,3 @@ interface tx_mkforms_forms_IForm
      */
     public function getDataHandler();
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_IForm.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_IForm.php'];
-}

--- a/forms/class.tx_mkforms_forms_IJSFramework.php
+++ b/forms/class.tx_mkforms_forms_IJSFramework.php
@@ -145,9 +145,3 @@ class tx_mkforms_forms_PageInclude implements tx_mkforms_forms_IPageInclude
         return $this->isJS;
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_IJSFramework.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/forms/class.tx_mkforms_forms_IJSFramework.php'];
-}

--- a/hooks/class.tx_mkforms_hooks_TSFE.php
+++ b/hooks/class.tx_mkforms_hooks_TSFE.php
@@ -16,9 +16,3 @@ class tx_mkforms_hooks_TSFE implements Tx_Rnbase_Interface_Singleton
         }
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/hooks/class.tx_mkforms_hooks_TSFE.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/hooks/class.tx_mkforms_hooks_TSFE.php'];
-}

--- a/js/class.tx_mkforms_js_DefaultFramework.php
+++ b/js/class.tx_mkforms_js_DefaultFramework.php
@@ -86,9 +86,3 @@ class tx_mkforms_js_DefaultFramework implements tx_mkforms_forms_IJSFramework
     {
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_js_DefaultFramework.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_js_DefaultFramework.php'];
-}

--- a/js/class.tx_mkforms_js_Loader.php
+++ b/js/class.tx_mkforms_js_Loader.php
@@ -753,9 +753,3 @@ JAVASCRIPT;
         unset($this->oForm);
     }
 }
-
-if (defined('TYPO3_MODE')
-    && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_js_Loader.php']
-) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_js_Loader.php'];
-}

--- a/renderer/be/class.tx_mkforms_renderer_be_Main.php
+++ b/renderer/be/class.tx_mkforms_renderer_be_Main.php
@@ -33,7 +33,3 @@ class tx_mkforms_renderer_be_Main extends formidable_mainrenderer
         return $sHtml;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_be/api/class.tx_rdrbe.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_be/api/class.tx_rdrbe.php'];
-}

--- a/renderer/fluid/class.tx_mkforms_renderer_fluid_Main.php
+++ b/renderer/fluid/class.tx_mkforms_renderer_fluid_Main.php
@@ -131,7 +131,3 @@ class tx_mkforms_renderer_fluid_Main extends formidable_mainrenderer
         require_once $this->sFluidPath.'Classes/ViewHelpers/TypolinkViewHelper.php';
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_fluid/api/class.tx_rdrfluid.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_fluid/api/class.tx_rdrfluid.php'];
-}

--- a/renderer/std/class.tx_mkforms_renderer_std_Main.php
+++ b/renderer/std/class.tx_mkforms_renderer_std_Main.php
@@ -42,7 +42,3 @@ class tx_mkforms_renderer_std_Main extends formidable_mainrenderer
         return $sHtml;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_std/api/class.tx_rdrstd.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_std/api/class.tx_rdrstd.php'];
-}

--- a/renderer/template/class.tx_mkforms_renderer_template_Main.php
+++ b/renderer/template/class.tx_mkforms_renderer_template_Main.php
@@ -166,7 +166,3 @@ class tx_mkforms_renderer_template_Main extends formidable_mainrenderer
         $this->baseCleanBeforeSession();
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_template/api/class.tx_rdrtemplate.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_template/api/class.tx_rdrtemplate.php'];
-}

--- a/renderer/void/class.tx_mkforms_renderer_void_Main.php
+++ b/renderer/void/class.tx_mkforms_renderer_void_Main.php
@@ -13,7 +13,3 @@ class tx_mkforms_renderer_void_Main extends formidable_mainrenderer
         return $this->_wrapIntoForm('');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_void/api/class.tx_rdrvoid.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdr_void/api/class.tx_rdrvoid.php'];
-}

--- a/res/minify/lib/jsmin.php
+++ b/res/minify/lib/jsmin.php
@@ -298,7 +298,3 @@ class JSMin
         return $this->lookAhead;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/res/minify/minify.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/res/minify/minify.php'];
-}

--- a/res/minify/minify.php
+++ b/res/minify/minify.php
@@ -541,7 +541,3 @@ class Minify
         return $filepath;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/res/minify/minify.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/res/minify/minify.php'];
-}

--- a/res/shared/php/class.defaultsandbox.php
+++ b/res/shared/php/class.defaultsandbox.php
@@ -3,7 +3,3 @@
 class formidable_defaultsandbox
 {
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/res/shared/php/class.defaultsandbox.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/res/shared/php/class.defaultsandbox.php'];
-}

--- a/session/class.tx_mkforms_session_Factory.php
+++ b/session/class.tx_mkforms_session_Factory.php
@@ -41,7 +41,3 @@ class tx_mkforms_session_Factory
         return self::$manager;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_session_Factory.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_session_Factory.php'];
-}

--- a/session/class.tx_mkforms_session_MixedSessionManager.php
+++ b/session/class.tx_mkforms_session_MixedSessionManager.php
@@ -401,7 +401,3 @@ class tx_mkforms_session_MixedSessionManager implements tx_mkforms_session_IMana
         return $this->form;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_session_MixedSessionManager.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_session_MixedSessionManager.php'];
-}

--- a/tests/action/class.tx_mkforms_tests_action_FormBaseTest.php
+++ b/tests/action/class.tx_mkforms_tests_action_FormBaseTest.php
@@ -322,7 +322,3 @@ class tx_mkforms_tests_action_FormBaseTest extends tx_rnbase_tests_BaseTestCase
         self::assertFalse(isset($fillData['widget-remove']), 'LINE:'.__LINE__);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/action/class.tx_mkforms_tests_action_FormBase_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/action/class.tx_mkforms_tests_action_FormBase_testcase.php'];
-}

--- a/tests/api/class.tx_mkforms_tests_api_maindatahandlerTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_maindatahandlerTest.php
@@ -114,7 +114,3 @@ class tx_mkforms_tests_api_maindatahandlerTest extends tx_rnbase_tests_BaseTestC
         self::assertFalse(isset($formData['widget-thatDoesNotExistInTheXml2']), 'wert für nicht existentes widget nicht auf null gesetzt');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php'];
-}

--- a/tests/api/class.tx_mkforms_tests_api_mainrendererTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainrendererTest.php
@@ -139,7 +139,3 @@ class tx_mkforms_tests_api_mainrendererTest extends tx_rnbase_tests_BaseTestCase
         self::assertContains('action="/url.html?parameter=test&amp;xss=&quot;/&gt;ohoh"', $renderedData['FORMBEGIN']);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php'];
-}

--- a/tests/api/class.tx_mkforms_tests_api_mainvalidatorTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainvalidatorTest.php
@@ -154,7 +154,3 @@ class tx_mkforms_tests_api_mainvalidatorTest extends tx_rnbase_tests_BaseTestCas
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php'];
-}

--- a/tests/api/class.tx_mkforms_tests_api_tx_ameosformidableTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_tx_ameosformidableTest.php
@@ -244,7 +244,3 @@ class tx_mkforms_tests_api_tx_ameosformidableTest extends tx_rnbase_tests_BaseTe
         self::assertEquals(Tx_Rnbase_Utility_T3General::getIndpEnv('REQUEST_URI'), tx_mkforms_tests_Util::getForm()->getFormAction());
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/api/class.tx_mkforms_tests_api_mainvalidator_testcase.php'];
-}

--- a/tests/class.tx_mkforms_tests_Util.php
+++ b/tests/class.tx_mkforms_tests_Util.php
@@ -229,7 +229,3 @@ class tx_mkforms_tests_Util
         return null;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mklib/tests/class.tx_mklib_tests_Util.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mklib/tests/class.tx_mklib_tests_Util.php'];
-}

--- a/tests/util/class.tx_mkforms_tests_util_DivTest.php
+++ b/tests/util/class.tx_mkforms_tests_util_DivTest.php
@@ -165,7 +165,3 @@ class tx_mkforms_tests_util_DivTest extends tx_rnbase_tests_BaseTestCase
         ];
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php'];
-}

--- a/tests/util/class.tx_mkforms_tests_util_FormBaseAjaxTest.php
+++ b/tests/util/class.tx_mkforms_tests_util_FormBaseAjaxTest.php
@@ -45,7 +45,3 @@ class tx_mkforms_tests_util_FormBaseAjaxTest extends tx_rnbase_tests_BaseTestCas
         self::assertEquals('repaint', $ret['method'], 'Es wurde nicht die richtige Methode zurück gegeben!');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php'];
-}

--- a/tests/util/class.tx_mkforms_tests_util_FormBaseTest.php
+++ b/tests/util/class.tx_mkforms_tests_util_FormBaseTest.php
@@ -140,7 +140,3 @@ class tx_mkforms_tests_util_FormBaseTest extends tx_rnbase_tests_BaseTestCase
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php'];
-}

--- a/tests/util/class.tx_mkforms_tests_util_FormFillTest.php
+++ b/tests/util/class.tx_mkforms_tests_util_FormFillTest.php
@@ -105,7 +105,3 @@ class tx_mkforms_tests_util_FormFillTest extends tx_rnbase_tests_BaseTestCase
         self::assertEquals(41, $countries[3]['value']);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Div_testcase.php'];
-}

--- a/tests/util/class.tx_mkforms_tests_util_JsonTest.php
+++ b/tests/util/class.tx_mkforms_tests_util_JsonTest.php
@@ -44,7 +44,3 @@ class tx_mkforms_tests_util_JsonTest extends tx_rnbase_tests_BaseTestCase
         self::assertEquals('"davor \n dazwischen\ndahinter"', $json);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Json_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/util/class.tx_mkforms_tests_util_Json_testcase.php'];
-}

--- a/tests/widgets/class.tx_mkforms_tests_widgets_fluidviewhelperTest.php
+++ b/tests/widgets/class.tx_mkforms_tests_widgets_fluidviewhelperTest.php
@@ -186,7 +186,3 @@ class tx_mkforms_tests_widgets_fluidviewhelperTest extends tx_rnbase_tests_BaseT
         return $methods;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/widgets/class.tx_mkforms_tests_widgets_fluidviewhelper_testcase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/tests/widgets/class.tx_mkforms_tests_widgets_fluidviewhelper_testcase.php'];
-}

--- a/util/class.tx_mkforms_util_AutoLoad.php
+++ b/util/class.tx_mkforms_util_AutoLoad.php
@@ -130,7 +130,3 @@ function mkformsUnserializeCallbackFunc($sClassName)
 {
     tx_mkforms_util_AutoLoad::unserializeCallbackFunc($sClassName);
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_AutoLoad.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_AutoLoad.php'];
-}

--- a/util/class.tx_mkforms_util_Config.php
+++ b/util/class.tx_mkforms_util_Config.php
@@ -1123,7 +1123,3 @@ class tx_mkforms_util_Config
         return $cfg;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Config.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Config.php'];
-}

--- a/util/class.tx_mkforms_util_Constants.php
+++ b/util/class.tx_mkforms_util_Constants.php
@@ -31,7 +31,3 @@ class tx_mkforms_util_Constants
     const FORM_ENCTYPE_MULTIPART_FORM_DATA = 'multipart/form-data';
     const FORM_ENCTYPE_TEXT_PLAIN = 'text/plain';
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Config.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Config.php'];
-}

--- a/util/class.tx_mkforms_util_DamUpload.php
+++ b/util/class.tx_mkforms_util_DamUpload.php
@@ -54,7 +54,3 @@ class tx_mkforms_util_DamUpload
         return isset($damPics['rows']) ? $damPics['rows'] : [];
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_DamUpload.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_DamUpload.php'];
-}

--- a/util/class.tx_mkforms_util_Div.php
+++ b/util/class.tx_mkforms_util_Div.php
@@ -891,7 +891,3 @@ ERRORMESSAGE;
         return $tsArray;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Div.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Div.php'];
-}

--- a/util/class.tx_mkforms_util_FormBase.php
+++ b/util/class.tx_mkforms_util_FormBase.php
@@ -681,7 +681,3 @@ class tx_mkforms_util_FormBase
         return $configurationValue;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_FormBase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_FormBase.php'];
-}

--- a/util/class.tx_mkforms_util_FormBaseAjax.php
+++ b/util/class.tx_mkforms_util_FormBaseAjax.php
@@ -476,7 +476,3 @@ class tx_mkforms_util_FormBaseAjax extends tx_mkforms_util_FormBase
         return $form->getWidget($params['dependsonflag']);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_FormBaseAjax.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_FormBaseAjax.php'];
-}

--- a/util/class.tx_mkforms_util_FormFill.php
+++ b/util/class.tx_mkforms_util_FormFill.php
@@ -216,7 +216,3 @@ class tx_mkforms_util_FormFill
         return $countries;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_FormBase.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_FormBase.php'];
-}

--- a/util/class.tx_mkforms_util_Json.php
+++ b/util/class.tx_mkforms_util_Json.php
@@ -704,7 +704,3 @@ if (class_exists('PEAR_Error')) {
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Json.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Json.php'];
-}

--- a/util/class.tx_mkforms_util_Loader.php
+++ b/util/class.tx_mkforms_util_Loader.php
@@ -252,7 +252,3 @@ class tx_mkforms_util_Loader
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Loader.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Loader.php'];
-}

--- a/util/class.tx_mkforms_util_Runnable.php
+++ b/util/class.tx_mkforms_util_Runnable.php
@@ -833,7 +833,3 @@ class tx_mkforms_util_Runnable
         return false;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Runnable.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Runnable.php'];
-}

--- a/util/class.tx_mkforms_util_Templates.php
+++ b/util/class.tx_mkforms_util_Templates.php
@@ -720,7 +720,3 @@ class tx_mkforms_util_Templates
         return $runnable;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Templates.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Templates.php'];
-}

--- a/util/class.tx_mkforms_util_Validation.php
+++ b/util/class.tx_mkforms_util_Validation.php
@@ -98,7 +98,3 @@ class tx_mkforms_util_Validation
         return $runnable;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Validation.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_Validation.php'];
-}

--- a/util/class.tx_mkforms_util_XMLParser.php
+++ b/util/class.tx_mkforms_util_XMLParser.php
@@ -429,7 +429,3 @@ class tx_mkforms_util_XMLParser
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_XMLParser.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/class.tx_mkforms_util_XMLParser.php'];
-}

--- a/validator/db/class.tx_mkforms_validator_db_Main.php
+++ b/validator/db/class.tx_mkforms_validator_db_Main.php
@@ -166,7 +166,3 @@ class tx_mkforms_validator_db_Main extends formidable_mainvalidator
         return !($rows[0]['nbentries'] > 0);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/db/class.tx_mkforms_validator_db_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/db/class.tx_mkforms_validator_db_Main.php'];
-}

--- a/validator/file/class.tx_mkforms_validator_file_Main.php
+++ b/validator/file/class.tx_mkforms_validator_file_Main.php
@@ -261,7 +261,3 @@ class tx_mkforms_validator_file_Main extends formidable_mainvalidator
         @unlink($sFullPath);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/file/class.tx_mkforms_validator_file_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/file/class.tx_mkforms_validator_file_Main.php'];
-}

--- a/validator/num/class.tx_mkforms_validator_num_Main.php
+++ b/validator/num/class.tx_mkforms_validator_num_Main.php
@@ -202,7 +202,3 @@ class tx_mkforms_validator_num_Main extends formidable_mainvalidator
         }
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/validator/class.tx_mkforms_util_validator_num_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/util/validator/class.tx_mkforms_util_validator_num_Main.php'];
-}

--- a/validator/preg/class.tx_mkforms_validator_preg_Main.php
+++ b/validator/preg/class.tx_mkforms_validator_preg_Main.php
@@ -95,7 +95,3 @@ class tx_mkforms_validator_preg_Main extends formidable_mainvalidator
         return preg_match($sPattern, $value);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/preg/class.tx_mkforms_validator_preg_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/preg/class.tx_mkforms_validator_preg_Main.php'];
-}

--- a/validator/std/class.tx_mkforms_validator_std_Main.php
+++ b/validator/std/class.tx_mkforms_validator_std_Main.php
@@ -7,7 +7,3 @@
 class tx_mkforms_validator_std_Main extends formidable_mainvalidator
 {
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/std/class.tx_mkforms_validator_std_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/validator/std/class.tx_mkforms_validator_std_Main.php'];
-}

--- a/view/class.tx_mkforms_view_Form.php
+++ b/view/class.tx_mkforms_view_Form.php
@@ -256,7 +256,3 @@ class tx_mkforms_view_Form extends tx_rnbase_view_Base
         return $subpart ? $subpart : '###DATA###';
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/view/class.tx_mkforms_view_Form.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/view/class.tx_mkforms_view_Form.php'];
-}

--- a/widgets/accordion/class.tx_mkforms_widgets_accordion_Main.php
+++ b/widgets/accordion/class.tx_mkforms_widgets_accordion_Main.php
@@ -201,7 +201,3 @@ STYLE;
         return $this->oForm->_defaultFalse('/childs/autowrap/');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_accordion/api/class.tx_rdtaccordion.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_accordion/api/class.tx_rdtaccordion.php'];
-}

--- a/widgets/autocomplete/class.tx_mkforms_widgets_autocomplete_Main.php
+++ b/widgets/autocomplete/class.tx_mkforms_widgets_autocomplete_Main.php
@@ -460,7 +460,3 @@ class tx_mkforms_widgets_autocomplete_Main extends formidable_mainrenderlet
         return;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/autocomplete/class.tx_mkforms_widgets_autocomplete_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/autocomplete/class.tx_mkforms_widgets_autocomplete_Main.php'];
-}

--- a/widgets/box/class.tx_mkforms_widgets_box_Main.php
+++ b/widgets/box/class.tx_mkforms_widgets_box_Main.php
@@ -290,7 +290,3 @@ Droppables.add("'.$sHtmlId.'", '.$sJson.');
         return $aChilds;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_box/api/class.tx_rdtbox.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_box/api/class.tx_rdtbox.php'];
-}

--- a/widgets/button/class.tx_mkforms_widgets_button_Main.php
+++ b/widgets/button/class.tx_mkforms_widgets_button_Main.php
@@ -46,7 +46,3 @@ class tx_mkforms_widgets_button_Main extends formidable_mainrenderlet
         return $this->_defaultTrue('/activelistable/');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_button/api/class.tx_rdtbutton.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_button/api/class.tx_rdtbutton.php'];
-}

--- a/widgets/captcha/class.tx_mkforms_widgets_captcha_Main.php
+++ b/widgets/captcha/class.tx_mkforms_widgets_captcha_Main.php
@@ -532,7 +532,3 @@ class tx_mkforms_widgets_captcha_Main extends formidable_mainrenderlet
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_captcha/api/class.tx_rdtcaptcha.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_captcha/api/class.tx_rdtcaptcha.php'];
-}

--- a/widgets/checkbox/class.tx_mkforms_widgets_checkbox_Main.php
+++ b/widgets/checkbox/class.tx_mkforms_widgets_checkbox_Main.php
@@ -323,7 +323,3 @@ class tx_mkforms_widgets_checkbox_Main extends formidable_mainrenderlet
         return parent::setValue(is_array($mValue) || empty($mValue) ? $mValue : [$mValue]);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_checkbox/api/class.tx_rdtcheckbox.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_checkbox/api/class.tx_rdtcheckbox.php'];
-}

--- a/widgets/checksingle/class.tx_mkforms_widgets_checksingle_Main.php
+++ b/widgets/checksingle/class.tx_mkforms_widgets_checksingle_Main.php
@@ -157,7 +157,3 @@ class tx_mkforms_widgets_checksingle_Main extends formidable_mainrenderlet
         return 0 === (int) $iValue;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_checksingle/api/class.tx_rdtchecksingle.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_checksingle/api/class.tx_rdtchecksingle.php'];
-}

--- a/widgets/chooser/class.tx_mkforms_widgets_chooser_Main.php
+++ b/widgets/chooser/class.tx_mkforms_widgets_chooser_Main.php
@@ -181,7 +181,3 @@ JAVASCRIPT;
         return $this->_defaultTrue('/searchable');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_chooser/api/class.tx_rdtchooser.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_chooser/api/class.tx_rdtchooser.php'];
-}

--- a/widgets/date/class.tx_mkforms_widgets_date_Main.php
+++ b/widgets/date/class.tx_mkforms_widgets_date_Main.php
@@ -419,7 +419,3 @@ class tx_mkforms_widgets_date_Main extends formidable_mainrenderlet
         return $mValue;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_date/api/class.tx_rdtdate.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_date/api/class.tx_rdtdate.php'];
-}

--- a/widgets/date/res/lib/js_calendar/calendar.php
+++ b/widgets/date/res/lib/js_calendar/calendar.php
@@ -156,7 +156,3 @@ class DHTML_Calendar
         return $attrstr;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_date/res/lib/js_calendar/calendar.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_date/res/lib/js_calendar/calendar.php'];
-}

--- a/widgets/dewplayer/class.tx_mkforms_widgets_dewplayer_Main.php
+++ b/widgets/dewplayer/class.tx_mkforms_widgets_dewplayer_Main.php
@@ -96,7 +96,3 @@ FLASHOBJECT;
         return $sPath;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_dewplayer/api/class.tx_rdtdewplayer.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_dewplayer/api/class.tx_rdtdewplayer.php'];
-}

--- a/widgets/fluidviewhelper/class.tx_mkforms_widgets_fluidviewhelper_Main.php
+++ b/widgets/fluidviewhelper/class.tx_mkforms_widgets_fluidviewhelper_Main.php
@@ -177,7 +177,3 @@ class tx_mkforms_widgets_fluidviewhelper_Main extends formidable_mainrenderlet
         return $htmlBag;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/fluidviewhelper/class.tx_mkforms_widgets_fluidviewhelper_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/fluidviewhelper/class.tx_mkforms_widgets_fluidviewhelper_Main.php'];
-}

--- a/widgets/hidden/class.tx_mkforms_widgets_hidden_Main.php
+++ b/widgets/hidden/class.tx_mkforms_widgets_hidden_Main.php
@@ -50,7 +50,3 @@ class tx_mkforms_widgets_hidden_Main extends formidable_mainrenderlet
         return true;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_hidden/api/class.tx_rdthidden.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_hidden/api/class.tx_rdthidden.php'];
-}

--- a/widgets/i18n/class.tx_mkforms_widgets_i18n_Main.php
+++ b/widgets/i18n/class.tx_mkforms_widgets_i18n_Main.php
@@ -233,7 +233,3 @@ TYPOSCRIPT;
         $this->baseCleanBeforeSession();
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_i18n/api/class.tx_rdti18n.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_i18n/api/class.tx_rdti18n.php'];
-}

--- a/widgets/img/class.tx_mkforms_widgets_img_Main.php
+++ b/widgets/img/class.tx_mkforms_widgets_img_Main.php
@@ -304,7 +304,3 @@ class tx_mkforms_widgets_img_Main extends formidable_mainrenderlet
         return $aAddParams;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_img/api/class.tx_rdtimg.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_img/api/class.tx_rdtimg.php'];
-}

--- a/widgets/jstree/class.tx_mkforms_widgets_jstree_Main.php
+++ b/widgets/jstree/class.tx_mkforms_widgets_jstree_Main.php
@@ -191,7 +191,3 @@ INITSCRIPT;
         return false;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_jstree/api/class.tx_rdttext.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_jstree/api/class.tx_rdttext.php'];
-}

--- a/widgets/label/class.tx_mkforms_widgets_label_Main.php
+++ b/widgets/label/class.tx_mkforms_widgets_label_Main.php
@@ -34,7 +34,3 @@ class tx_mkforms_widgets_label_Main extends formidable_mainrenderlet
         return true;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_lbl/api/class.tx_rdtlbl.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_lbl/api/class.tx_rdtlbl.php'];
-}

--- a/widgets/link/class.tx_mkforms_widgets_link_Main.php
+++ b/widgets/link/class.tx_mkforms_widgets_link_Main.php
@@ -207,7 +207,3 @@ class tx_mkforms_widgets_link_Main extends formidable_mainrenderlet
         return $this->buildMajixExecuter('follow', $bDisplayLoader);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_link/api/class.tx_rdtlink.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_link/api/class.tx_rdtlink.php'];
-}

--- a/widgets/listbox/class.tx_mkforms_widgets_listbox_Main.php
+++ b/widgets/listbox/class.tx_mkforms_widgets_listbox_Main.php
@@ -356,7 +356,3 @@ class tx_mkforms_widgets_listbox_Main extends formidable_mainrenderlet
         return 0 === count($aItems) || (1 === count($aItems) && '' === trim($aItems[array_shift(array_keys($aItems))]['value']));
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_listbox/api/class.tx_rdtlistbox.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_listbox/api/class.tx_rdtlistbox.php'];
-}

--- a/widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+++ b/widgets/lister/class.tx_mkforms_widgets_lister_Main.php
@@ -1912,7 +1912,3 @@ ERRORMESSAGE;
         return $value;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/lister/class.tx_mkforms_widgets_lister_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/lister/class.tx_mkforms_widgets_lister_Main.php'];
-}

--- a/widgets/listerselect/class.tx_mkforms_widgets_listerselect_Main.php
+++ b/widgets/listerselect/class.tx_mkforms_widgets_listerselect_Main.php
@@ -203,7 +203,3 @@ class tx_mkforms_widgets_listerselect_Main extends formidable_mainrenderlet
         return $this->_defaultTrue('/activelistable/');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_radio/api/class.tx_mkforms_widgets_listerselect_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_radio/api/class.tx_mkforms_widgets_listerselect_Main.php'];
-}

--- a/widgets/modalbox/class.tx_mkforms_widgets_modalbox_Main.php
+++ b/widgets/modalbox/class.tx_mkforms_widgets_modalbox_Main.php
@@ -124,7 +124,3 @@ class tx_mkforms_widgets_modalbox_Main extends formidable_mainrenderlet
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_modalbox/api/class.tx_rdtmodalbox.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_modalbox/api/class.tx_rdtmodalbox.php'];
-}

--- a/widgets/modalbox2/class.tx_mkforms_widgets_modalbox2_Main.php
+++ b/widgets/modalbox2/class.tx_mkforms_widgets_modalbox2_Main.php
@@ -130,7 +130,3 @@ class tx_mkforms_widgets_modalbox2_Main extends formidable_mainrenderlet
         );
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_modalbox2/api/class.tx_rdtmodalbox2.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_modalbox2/api/class.tx_rdtmodalbox2.php'];
-}

--- a/widgets/passthru/class.tx_mkforms_widgets_passthru_Main.php
+++ b/widgets/passthru/class.tx_mkforms_widgets_passthru_Main.php
@@ -26,7 +26,3 @@ class tx_mkforms_widgets_passthru_Main extends formidable_mainrenderlet
         return false;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_passthru/api/class.tx_rdtpassthru.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_passthru/api/class.tx_rdtpassthru.php'];
-}

--- a/widgets/progressbar/class.tx_mkforms_widgets_progressbar_Main.php
+++ b/widgets/progressbar/class.tx_mkforms_widgets_progressbar_Main.php
@@ -232,7 +232,3 @@ class tx_mkforms_widgets_progressbar_Main extends formidable_mainrenderlet
         return $aStyles;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/ap/base/rdt_progressbar/api/class.tx_rdtprogressbar.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_progressbar/api/class.tx_rdtprogressbar.php'];
-}

--- a/widgets/pwd/class.tx_mkforms_widgets_pwd_Main.php
+++ b/widgets/pwd/class.tx_mkforms_widgets_pwd_Main.php
@@ -25,7 +25,3 @@ class tx_mkforms_widgets_pwd_Main extends formidable_mainrenderlet
         return true;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_pwd/api/class.tx_rdtpwd.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_pwd/api/class.tx_rdtpwd.php'];
-}

--- a/widgets/radio/class.tx_mkforms_widgets_radio_Main.php
+++ b/widgets/radio/class.tx_mkforms_widgets_radio_Main.php
@@ -206,7 +206,3 @@ class tx_mkforms_widgets_radio_Main extends formidable_mainrenderlet
         return $this->_defaultTrue('/activelistable/');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_radio/api/class.tx_rdtradio.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_radio/api/class.tx_rdtradio.php'];
-}

--- a/widgets/reset/class.tx_mkforms_widgets_reset_Main.php
+++ b/widgets/reset/class.tx_mkforms_widgets_reset_Main.php
@@ -31,7 +31,3 @@ class tx_mkforms_widgets_reset_Main extends formidable_mainrenderlet
         return true;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/submit/class.tx_mkforms_widgets_submit_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/submit/class.tx_mkforms_widgets_submit_Main.php'];
-}

--- a/widgets/searchform/class.tx_mkforms_widgets_searchform_Main.php
+++ b/widgets/searchform/class.tx_mkforms_widgets_searchform_Main.php
@@ -471,7 +471,3 @@ class tx_mkforms_widgets_searchform_Main extends formidable_mainrenderlet
         return false;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_searchform/api/class.tx_rdtsearchform.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_searchform/api/class.tx_rdtsearchform.php'];
-}

--- a/widgets/selector/class.tx_mkforms_widgets_selector_Main.php
+++ b/widgets/selector/class.tx_mkforms_widgets_selector_Main.php
@@ -489,7 +489,3 @@ PHP;
         $this->baseCleanBeforeSession();
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_selector/api/class.tx_rdtselector.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_selector/api/class.tx_rdtselector.php'];
-}

--- a/widgets/submit/class.tx_mkforms_widgets_submit_Main.php
+++ b/widgets/submit/class.tx_mkforms_widgets_submit_Main.php
@@ -116,7 +116,3 @@ class tx_mkforms_widgets_submit_Main extends formidable_mainrenderlet
         return $this->_defaultTrue('/activelistable');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/submit/class.tx_mkforms_widgets_submit_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/submit/class.tx_mkforms_widgets_submit_Main.php'];
-}

--- a/widgets/swfupload/class.tx_mkforms_widgets_swfupload_Main.php
+++ b/widgets/swfupload/class.tx_mkforms_widgets_swfupload_Main.php
@@ -407,7 +407,3 @@ JAVASCRIPT;
         return $this->oForm->getConfigXML()->getLLLabel($sFileTypeDesc);
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/swfupload/class.tx_rdtswfupload.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/swfupload/class.tx_rdtswfupload.php'];
-}

--- a/widgets/tab/class.tx_mkforms_widgets_tab_Main.php
+++ b/widgets/tab/class.tx_mkforms_widgets_tab_Main.php
@@ -79,7 +79,3 @@ class tx_mkforms_widgets_tab_Main extends formidable_mainrenderlet
         return true;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_tab/api/class.tx_rdttab.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_tab/api/class.tx_rdttab.php'];
-}

--- a/widgets/tabpanel/class.tx_mkforms_widgets_tabpanel_Main.php
+++ b/widgets/tabpanel/class.tx_mkforms_widgets_tabpanel_Main.php
@@ -162,7 +162,3 @@ class tx_mkforms_widgets_tabpanel_Main extends formidable_mainrenderlet
         return $this->oForm->_defaultFalse('/childs/autowrap/');
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_tabpanel/api/class.tx_rdttabpanel.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_tabpanel/api/class.tx_rdttabpanel.php'];
-}

--- a/widgets/text/class.tx_mkforms_widgets_text_Main.php
+++ b/widgets/text/class.tx_mkforms_widgets_text_Main.php
@@ -57,7 +57,3 @@ class tx_mkforms_widgets_text_Main extends formidable_mainrenderlet
         return $type;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_text/api/class.tx_mkforms_widgets_text_Text.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_text/api/class.tx_mkforms_widgets_text_Text.php'];
-}

--- a/widgets/ticker/class.tx_mkforms_widgets_ticker_Main.php
+++ b/widgets/ticker/class.tx_mkforms_widgets_ticker_Main.php
@@ -321,7 +321,3 @@ class tx_mkforms_widgets_ticker_Main extends formidable_mainrenderlet
         return $sRes;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_ticker/api/class.tx_rdtticker.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/ameos_formidable/api/base/rdt_ticker/api/class.tx_rdtticker.php'];
-}

--- a/widgets/txtarea/class.tx_mkforms_widgets_txtarea_Main.php
+++ b/widgets/txtarea/class.tx_mkforms_widgets_txtarea_Main.php
@@ -52,7 +52,3 @@ class tx_mkforms_widgets_txtarea_Main extends formidable_mainrenderlet
         return nl2br(htmlspecialchars($sValue));
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/txtarea/class.tx_mkforms_widgets_txtarea_Main.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/txtarea/class.tx_mkforms_widgets_txtarea_Main.php'];
-}

--- a/widgets/upload/class.tx_mkforms_widgets_upload_Main.php
+++ b/widgets/upload/class.tx_mkforms_widgets_upload_Main.php
@@ -385,7 +385,3 @@ class tx_mkforms_widgets_upload_Main extends formidable_mainrenderlet
         return $this->bUseDam;
     }
 }
-
-if (defined('TYPO3_MODE') && $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/upload/class.tx_rdtupload.php']) {
-    include_once $GLOBALS['TYPO3_CONF_VARS'][TYPO3_MODE]['XCLASS']['ext/mkforms/widgets/upload/class.tx_rdtupload.php'];
-}


### PR DESCRIPTION
With modern TYPO3 versions, XCLASSing works without the XCLASS footers.

(This also removes one set of PSR-12 violations.)