### PR TITLE
[TASK] Stop requiring class files that can be autoloaded

### DIFF
--- a/api/class.inlineconfmethods.php
+++ b/api/class.inlineconfmethods.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainscriptingmethods.php';
-
 class formidable_inlineconfmethods extends formidable_mainscriptingmethods
 {
     public function &method_this(&$oRdt, $aParams)

--- a/api/class.majixmethods.php
+++ b/api/class.majixmethods.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.inlineconfmethods.php';
-
 class formidable_majixmethods extends formidable_inlineconfmethods
 {
 }

--- a/api/class.templatemethods.php
+++ b/api/class.templatemethods.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainscriptingmethods.php';
-
 class formidable_templatemethods extends formidable_mainscriptingmethods
 {
     private static $cache = null;

--- a/api/class.tx_ameosformidable.php
+++ b/api/class.tx_ameosformidable.php
@@ -26,15 +26,6 @@
  *
  * @author    Jerome Schneider <typo3dev@ameos.com>
  */
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainobject.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.maindataset.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.maindatasource.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainvalidator.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.maindatahandler.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainrenderer.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainrenderlet.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainactionlet.php';
-
 class tx_ameosformidable implements tx_mkforms_forms_IForm
 {
     /**
@@ -4837,7 +4828,7 @@ JAVASCRIPT;
     public function div_arrayToCsvString($aData, $sFSep = ';', $sLSep = "\r\n", $sStringWrap = '"')
     {
         // CSV class taken from http://snippets.dzone.com/posts/show/3128
-        require_once tx_rnbase_util_Extensions::extPath('mkforms').'res/shared/php/csv/class.csv.php';
+        require_once __DIR__ . '/../res/shared/php/csv/class.csv.php';
 
         $oCsv = new CSV(
             $sFSep,

--- a/api/class.tx_ameosformidable_pi.php
+++ b/api/class.tx_ameosformidable_pi.php
@@ -23,8 +23,6 @@ class tx_ameosformidable_pi extends Tx_Rnbase_Frontend_Plugin
             )
         );
 
-        require_once PATH_formidableapi;
-
         if ('' !== $sConfPath) {
             $aCurZone = &$GLOBALS['TSFE']->tmpl->setup;
 
@@ -65,7 +63,6 @@ class tx_ameosformidable_pi extends Tx_Rnbase_Frontend_Plugin
     {
         // init+render
 
-        require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.tx_ameosformidable.php';
         $this->oForm = tx_rnbase::makeInstance('tx_ameosformidable');
         if (false === $this->sXmlPath) {
             $this->oForm->initFromTs(

--- a/api/class.user_ameosformidable_cobj.php
+++ b/api/class.user_ameosformidable_cobj.php
@@ -63,7 +63,6 @@ class user_ameosformidable_cobj
 
     public function _render($conf)
     {
-        require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.tx_ameosformidable.php';
         $this->oForm = tx_rnbase::makeInstance('tx_ameosformidable');
         $this->oForm->initFromTs(
             $this,

--- a/bin/autoload-test.sh
+++ b/bin/autoload-test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/../.Build/vendor/autoload.php';
+
+$classes = [
+#  'class.mainobject.php' => 'formidable_mainobject',
+#  'class.mainscriptingmethods.php' => 'formidable_mainscriptingmethods',
+#  'class.inlineconfmethods.php' => 'formidable_inlineconfmethods',
+#  'class.maindataset.php' => 'formidable_maindataset',
+#  'class.maindatasource.php' => 'formidable_maindatasource',
+#  'class.mainvalidator.php' => 'formidable_mainvalidator',
+#  'class.maindatahandler.php' => 'formidable_maindatahandler',
+#  'class.mainrenderer.php' => 'formidable_mainrenderer',
+#  'class.mainrenderlet.php' => 'formidable_mainrenderlet',
+#  'class.mainactionlet.php' => 'formidable_mainactionlet',
+#  'class.tx_ameosformidable.php' => 'tx_ameosformidable',
+#  'class.csv.php' => 'CSV',
+# 'jsmin.php' => 'JSMin',
+ '' => '',
+];
+
+foreach ($classes as $filename => $class) {
+    echo ($class);
+    if (class_exists($class)) {
+        echo ': is autoloadable: ' . $filename;
+    } else {
+        echo ': is not autoloadable.';
+    }
+    echo "\n";
+}

--- a/forms/class.tx_mkforms_forms_Base.php
+++ b/forms/class.tx_mkforms_forms_Base.php
@@ -22,8 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.tx_ameosformidable.php';
-
 /**
  * Base for forms.
  */

--- a/forms/class.tx_mkforms_forms_IJSFramework.php
+++ b/forms/class.tx_mkforms_forms_IJSFramework.php
@@ -22,8 +22,6 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.tx_ameosformidable.php';
-
 /**
  * Factory for forms.
  */

--- a/remote/formidableajax.php
+++ b/remote/formidableajax.php
@@ -295,7 +295,6 @@ class formidableajax
             if ($BE_USER->checkLockToIP() && $BE_USER->checkBackendAccessSettingsFromInitPhp()) {
                 $BE_USER->extInitFeAdmin();
                 if ($BE_USER->extAdmEnabled) {
-                    require_once tx_rnbase_util_Extensions::extPath('lang').'lang.php';
                     $LANG = tx_rnbase::makeInstance('language');
                     $LANG->init($BE_USER->uc['lang']);
 

--- a/res/minify/minify.php
+++ b/res/minify/minify.php
@@ -238,7 +238,7 @@ class Minify
      */
     public function minifyJS($js)
     {
-        require_once dirname(__FILE__).'/lib/jsmin.php';
+        require_once __DIR__ . '/lib/jsmin.php';
 
         return JSMin::minify($js);
     }

--- a/tests/api/class.tx_mkforms_tests_api_maindatahandlerTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_maindatahandlerTest.php
@@ -25,12 +25,6 @@
  */
 
 /**
- * benötigte Klassen einbinden.
- */
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainobject.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.maindatahandler.php';
-
-/**
  * Testfälle für tx_mkforms_api_mainrenderlet
  * wir testen am beispiel des TEXT widgets.
  *

--- a/tests/api/class.tx_mkforms_tests_api_mainrendererTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainrendererTest.php
@@ -25,12 +25,6 @@
  */
 
 /**
- * benötigte Klassen einbinden.
- */
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainobject.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainrenderer.php';
-
-/**
  * Testfälle für tx_mkforms_api_mainrenderlet
  * wir testen am beispiel des TEXT widgets.
  *

--- a/tests/api/class.tx_mkforms_tests_api_mainrenderletTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainrenderletTest.php
@@ -25,12 +25,6 @@
  */
 
 /**
- * benötigte Klassen einbinden.
- */
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainobject.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainrenderlet.php';
-
-/**
  * Testfälle für tx_mkforms_api_mainrenderlet
  * wir testen am beispiel des TEXT widgets.
  *

--- a/tests/api/class.tx_mkforms_tests_api_mainvalidatorTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainvalidatorTest.php
@@ -25,12 +25,6 @@
  */
 
 /**
- * benötigte Klassen einbinden.
- */
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainobject.php';
-require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/class.mainvalidator.php';
-
-/**
  * Testfälle für tx_mkforms_util_Solr.
  *
  * @author hbochmann

--- a/util/class.tx_mkforms_util_FormBaseAjax.php
+++ b/util/class.tx_mkforms_util_FormBaseAjax.php
@@ -99,7 +99,7 @@ class tx_mkforms_util_FormBaseAjax extends tx_mkforms_util_FormBase
      *                          example: <param get="setStatusMessage::status__statusSaved|LLL:EXT:mkhogafe/locallang.xml:header_form_saved"/>
      *      * majixAction:      Name of method to be executed -
      *
-     * @see ext:mkforms/api/class.mainrenderlet.php:formidable_mainrenderlet->majix* functions
+     * @see formidable_mainrenderlet->majix* functions
      *                          Give names like "displayNone", "hidden" etc. in order to call "majixDisplayNone()",
      *                          "majixHidden()" etc. respectively.
      *                          Additionally evaluated function name:

--- a/util/class.tx_mkforms_util_Templates.php
+++ b/util/class.tx_mkforms_util_Templates.php
@@ -646,7 +646,7 @@ class tx_mkforms_util_Templates
 
         $sClassPath = 'class.'.$sInterpreter.'.php';
 
-        require_once tx_rnbase_util_Extensions::extPath('mkforms').'api/'.$sClassPath;
+        require_once __DIR__ . '/../api/' . $sClassPath;
         // TODO: Was ist das??
         // wird für template scripting benötigt
         // Bsp.: <!-- ###jobads-subtype.formData("jobads-maintype").equals(501) perimeter### begin-->

--- a/widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
+++ b/widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
@@ -673,7 +673,6 @@ class tx_mkforms_widgets_mediaupload_Main extends formidable_mainrenderlet
 
         if (!$GLOBALS['LANG']) {
             // Bei Ajax-Calls fehlt das Objekt
-            require_once tx_rnbase_util_Extensions::extPath('lang').'lang.php';
             $GLOBALS['LANG'] = tx_rnbase::makeInstance('language');
             $GLOBALS['LANG']->init($BE_USER->uc['lang']);
         }


### PR DESCRIPTION
This improves performance, unbreaks PHPStan and fixes
PSR-12 violations.

Also switch the require of non-autoloadable classes to be
PHPStan-friendly and faster.