### PR TITLE
[CLEANUP] Drop `type="text/javascript"` from `script` tags

### DIFF
--- a/api/class.mainrenderlet.php
+++ b/api/class.mainrenderlet.php
@@ -2635,7 +2635,7 @@ JAVASCRIPT;
         reset($aLibs);
         foreach ($aLibs as $sKey => $sLib) {
             $oJsLoader->additionalHeaderData(
-                '<script type="text/javascript" src="'.$oJsLoader->getScriptPath($this->sExtWebPath.$sLib).'"></script>',
+                '<script src="'.$oJsLoader->getScriptPath($this->sExtWebPath.$sLib).'"></script>',
                 $sKey
             );
         }

--- a/api/class.tx_ameosformidable.php
+++ b/api/class.tx_ameosformidable.php
@@ -2466,7 +2466,7 @@ SANDBOXCLASS;
                 );
             } else {
                 $this->additionalHeaderData(
-                    "<!-- BEGIN:Formidable '".$this->formid."' initialization-->\n"."<script type=\"text/javascript\">\n"
+                    "<!-- BEGIN:Formidable '".$this->formid."' initialization-->\n"."<script>\n"
                     .$sJs."\n</script>\n"."<!-- END:Formidable '".$this->formid."' initialization-->\n"
                 );
             }
@@ -2482,7 +2482,7 @@ SANDBOXCLASS;
             } else {
                 $this->additionalHeaderData(
                     "<!-- BEGIN:Formidable '".$this->formid."' post-initialization-->\n"
-                    ."<script type=\"text/javascript\">\n".$sJs."\n</script>\n"."<!-- END:Formidable '".$this->formid
+                    ."<script>\n".$sJs."\n</script>\n"."<!-- END:Formidable '".$this->formid
                     ."' post-initialization-->\n"
                 );
             }

--- a/js/class.tx_mkforms_js_Loader.php
+++ b/js/class.tx_mkforms_js_Loader.php
@@ -135,7 +135,7 @@ class tx_mkforms_js_Loader
     {
         $path = tx_mkforms_util_Div::removeStartingSlash(tx_mkforms_util_Div::toRelPath($sFilePath));
         $path = $this->getAbsRefPrefix().$path;
-        $this->aCodeBehindJsIncludes[$ref] = '<script type="text/javascript" src="'.
+        $this->aCodeBehindJsIncludes[$ref] = '<script src="'.
             $this->getForm()->getJSLoader()->getScriptPath($path).'"></script>';
     }
 
@@ -266,7 +266,7 @@ JAVASCRIPT;
         $includes[] = tx_mkforms_forms_PageInclude::createInstance($pagePath, $serverPath, 'tx_mkforms_json');
 
         foreach ($includes as $include) {
-            $tag = $include->isJS() ? '<script type="text/javascript" src="'.$this->getScriptPath($include->getPagePath()).'"></script>' :
+            $tag = $include->isJS() ? '<script src="'.$this->getScriptPath($include->getPagePath()).'"></script>' :
                 '<link href="'.$this->getScriptPath($include->getPagePath(), 'css').'" type="text/css" rel="stylesheet" />';
             $this->additionalHeaderData(
                 $tag,
@@ -295,7 +295,7 @@ JAVASCRIPT;
         $includes = $this->getJSFramework()->getEffectIncludes($this->getAbsRefPrefix());
 
         foreach ($includes as $include) {
-            $tag = $include->isJS() ? '<script type="text/javascript" src="'.$this->getScriptPath($include->getPagePath()).'"></script>' :
+            $tag = $include->isJS() ? '<script src="'.$this->getScriptPath($include->getPagePath()).'"></script>' :
                 '<link href="'.$this->getScriptPath($include->getPagePath(), 'css').'" type="text/css" rel="stylesheet" />';
             $this->additionalHeaderData(
                 $tag,
@@ -316,7 +316,7 @@ JAVASCRIPT;
             $sPath = $this->getAbsRefPrefix().$mkformsPath.'Resources/Public/JavaScript/scriptaculous/dragdrop.js';
 
             $this->additionalHeaderData(
-                '<script type="text/javascript" src="'.$this->getScriptPath($sPath).'"></script>',
+                '<script src="'.$this->getScriptPath($sPath).'"></script>',
                 'tx_ameosformidable_scriptaculous_dragdrop',
                 $bFirstPos = false,
                 $sBefore = false,
@@ -330,7 +330,7 @@ JAVASCRIPT;
             $sPath = $this->getAbsRefPrefix().$mkformsPath.'Resources/Public/JavaScript/scriptaculous/builder.js';
 
             $this->additionalHeaderData(
-                '<script type="text/javascript" src="'.$this->getScriptPath($sPath).'"></script>',
+                '<script src="'.$this->getScriptPath($sPath).'"></script>',
                 'tx_ameosformidable_scriptaculous_builder',
                 $bFirstPos = false,
                 $sBefore = false,
@@ -356,7 +356,7 @@ JAVASCRIPT;
                 tx_rnbase_util_Extensions::extPath('mkforms')
             ).
             'Resources/Public/JavaScript/framework.js';
-        $tag = '<script type="text/javascript" src="'.$this->getScriptPath($sPath).'"></script>';
+        $tag = '<script src="'.$this->getScriptPath($sPath).'"></script>';
         $this->additionalHeaderData(
             $tag,
             'tx_ameosformidable_jsframework',
@@ -447,7 +447,7 @@ JAVASCRIPT;
             $sPath = $this->getAbsRefPrefix().$mkformsPath.'Resources/Public/JavaScript/tooltip/tooltips.js';
 
             $this->additionalHeaderData(
-                '<script type="text/javascript" src="'.$sPath.'"></script>',
+                '<script src="'.$sPath.'"></script>',
                 'tx_ameosformidable_tooltip_js',
                 $bFirstPos = false,
                 $sBefore = false,
@@ -550,7 +550,7 @@ JAVASCRIPT;
             switch ($ext) {
                 case 'js':
                     $script = 'typo3temp/assets/mkforms/javascript_'.substr(md5($str), 0, 10).'.js';
-                    $output = $sDesc."\n".'<script type="text/javascript" src="'.htmlspecialchars(
+                    $output = $sDesc."\n".'<script src="'.htmlspecialchars(
                         $this->getAbsRefPrefix().$script
                     ).'"></script>'."\n\n";
                     break;

--- a/tests/api/class.tx_mkforms_tests_api_mainrenderletTest.php
+++ b/tests/api/class.tx_mkforms_tests_api_mainrenderletTest.php
@@ -127,7 +127,7 @@ class tx_mkforms_tests_api_mainrenderletTest extends tx_rnbase_tests_BaseTestCas
         if (defined('TYPO3_cliMode') && TYPO3_cliMode) {
             $this->markTestSkipped('Dieser Test kann nur nur manuell für Analysen gestartet werden.');
         }
-        $this->oForm->getWidget('widget-text')->setValue('<script type="text/javascript">alert("XSS");</script>');
+        $this->oForm->getWidget('widget-text')->setValue('<script>alert("XSS");</script>');
 
         $dTime = microtime(true);
         // sind 100 aufrufe real? es sind sicher um einiges mehr.
@@ -150,7 +150,7 @@ class tx_mkforms_tests_api_mainrenderletTest extends tx_rnbase_tests_BaseTestCas
         if (defined('TYPO3_cliMode') && TYPO3_cliMode) {
             $this->markTestSkipped('Dieser Test kann nur nur manuell für Analysen gestartet werden.');
         }
-        $this->oForm->getWidget('widget-text2')->setValue('<script type="text/javascript">alert("XSS");</script>');
+        $this->oForm->getWidget('widget-text2')->setValue('<script>alert("XSS");</script>');
 
         $dTime = microtime(true);
         // sind 100 aufrufe real? es sind sicher um einiges mehr.

--- a/widgets/date/class.tx_mkforms_widgets_date_Main.php
+++ b/widgets/date/class.tx_mkforms_widgets_date_Main.php
@@ -385,9 +385,9 @@ class tx_mkforms_widgets_date_Main extends formidable_mainrenderlet
 
         $oJsLoader->additionalHeaderData(
             (
-                '<script type="text/javascript" src="'.$oJsLoader->getScriptPath(Tx_Rnbase_Utility_T3General::getIndpEnv('TYPO3_SITE_URL').$this->sExtRelPath.'res/lib/js_calendar/calendar.js').'"></script>'.
-                '<script type="text/javascript" src="'.$oJsLoader->getScriptPath($sLangFile).'"></script>'.
-                '<script type="text/javascript" src="'.$oJsLoader->getScriptPath(Tx_Rnbase_Utility_T3General::getIndpEnv('TYPO3_SITE_URL').$this->sExtRelPath.'res/lib/js_calendar/calendar-setup.js').'"></script>'.
+                '<script src="'.$oJsLoader->getScriptPath(Tx_Rnbase_Utility_T3General::getIndpEnv('TYPO3_SITE_URL').$this->sExtRelPath.'res/lib/js_calendar/calendar.js').'"></script>'.
+                '<script src="'.$oJsLoader->getScriptPath($sLangFile).'"></script>'.
+                '<script src="'.$oJsLoader->getScriptPath(Tx_Rnbase_Utility_T3General::getIndpEnv('TYPO3_SITE_URL').$this->sExtRelPath.'res/lib/js_calendar/calendar-setup.js').'"></script>'.
                 $css
             ),
             'mkforms_date_includeonce'

--- a/widgets/date/res/lib/js_calendar/calendar.php
+++ b/widgets/date/res/lib/js_calendar/calendar.php
@@ -56,13 +56,13 @@ class DHTML_Calendar
         $code = ('<link rel="stylesheet" type="text/css" media="all" href="'.
                    $this->calendar_lib_path.$this->calendar_theme_file.
                    '" />'.NEWLINE);
-        $code .= ('<script type="text/javascript" src="'.
+        $code .= ('<script src="'.
                    $this->calendar_lib_path.$this->calendar_file.
                    '"></script>'.NEWLINE);
-        $code .= ('<script type="text/javascript" src="'.
+        $code .= ('<script src="'.
                    $this->calendar_lib_path.$this->calendar_lang_file.
                    '"></script>'.NEWLINE);
-        $code .= ('<script type="text/javascript" src="'.
+        $code .= ('<script src="'.
                    $this->calendar_lib_path.$this->calendar_setup_file.
                    '"></script>');
 
@@ -72,7 +72,7 @@ class DHTML_Calendar
     public function _make_calendar($other_options = [])
     {
         $js_options = $this->_make_js_hash(array_merge($this->calendar_options, $other_options));
-        $code = ('<script type="text/javascript">Calendar.setup({'.
+        $code = ('<script>Calendar.setup({'.
                    $js_options.
                    '});</script>');
 

--- a/widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
+++ b/widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
@@ -695,7 +695,7 @@ class tx_mkforms_widgets_mediaupload_Main extends formidable_mainrenderlet
         $sFile = Tx_Rnbase_Utility_T3General::getIndpEnv('TYPO3_SITE_URL').$this->sExtRelPath.'res/js/'.$dir.'/ajaxfileupload.js';
 
         $oJsLoader->additionalHeaderData(
-            '<script type="text/javascript" src="'.$oJsLoader->getScriptPath($sFile).'"></script>',
+            '<script src="'.$oJsLoader->getScriptPath($sFile).'"></script>',
             'mkforms_mediaupload_includeonce'
         );
     }


### PR DESCRIPTION
This is not needed anymore with modern HTML versions.