### PR TITLE
[TASK] Enforce PHP 7.2-7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "typo3-ter/mkforms": "self.version"
     },
     "require": {
+        "php": "^7.2",
         "typo3/cms-core": "^9.5 || ^10.4",
         "digedag/rn-base": "^1.10.5"
     },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -35,7 +35,7 @@ $EM_CONF['mkforms'] = [
         'depends' => [
             'rn_base' => '1.10.5-',
             'typo3' => '9.5.0-10.4.99',
-            'php' => '5.6.0-8.9.99',
+            'php' => '7.2.0-7.4.99',
         ],
         'conflicts' => [
             'ameos_formidable' => '',


### PR DESCRIPTION
Now the PHP requirements are in sync with the supported TYPO3 versions
(9LTS and 10LTS).