### PR TITLE
[TASK] Streamline the PHP linting

### DIFF
--- a/.github/workflows/phpci.yml
+++ b/.github/workflows/phpci.yml
@@ -37,20 +37,6 @@ jobs:
                 name: "Validate composer.json and composer.lock"
                 run: "composer validate --strict"
             -
-                name: "Determine composer cache directory"
-                id: "determine-composer-cache-directory"
-                run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
-            -
-                name: "Cache dependencies installed with composer"
-                uses: "actions/cache@v2.0.0"
-                with:
-                    path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
-                    key: "php-${{ matrix.php-version }}-composer-${{ hashFiles('composer.lock') }}"
-                    restore-keys: "php-${{ matrix.php-version }}-composer-"
-            -
-                name: "Install composer dependencies"
-                run: "composer install --no-interaction --no-progress --no-suggest"
-            -
                 name: "Run Linter"
                 run: "composer lint:php"
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "require-dev": {
         "nimut/testing-framework": "^4.0 || ^5.0",
         "dmk/mklib": ">=3.0.8",
-        "php-parallel-lint/php-parallel-lint": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.16"
     },
     "autoload": {
@@ -87,8 +86,7 @@
             "[ -L .Build/Web/typo3conf/ext/mkforms ] || ln -snvf ../../../../. .Build/Web/typo3conf/ext/mkforms"
         ],
         "lint:php": [
-            "[ -e .Build/bin/parallel-lint ] || composer update",
-            ".Build/bin/parallel-lint  ./action ./api ./Classes ./dh ./ds ./exception ./forms ./hooks ./js ./remote ./renderer ./session ./tests ./util ./validator ./view ./widgets"
+            "find *.php action api Classes dh ds exception forms hooks js remote renderer session tests util validator view widgets -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l"
         ],
         "lint": [
             "@lint:php"


### PR DESCRIPTION
Stop using parallel linting:
This allows linting without doing a `composer install` first, i.e.,
it is not possible to lint with PHP versions for which the dependencies
are not available yet. This also speeds up the linting step.