### PR TITLE
[FEATURE] Check the codebase with PHPStan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,6 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.php_cs export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore

--- a/.github/workflows/phpci.yml
+++ b/.github/workflows/phpci.yml
@@ -65,6 +65,7 @@ jobs:
             matrix:
                 command:
                     - "test:phpcs"
+                    - "test:phpstan"
                 php-version:
                     - "7.4"
 

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,11 @@
         "nimut/testing-framework": "^4.0 || ^5.0",
         "dmk/mklib": ">=3.0.8",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "friendsofphp/php-cs-fixer": "^2.16"
+        "friendsofphp/php-cs-fixer": "^2.16",
+        "phpstan/phpstan": "^1.4.2",
+        "phpstan/phpstan-phpunit": "^1.0.0",
+        "phpstan/extension-installer": "^1.1.0",
+        "saschaegerer/phpstan-typo3": "^1.0.0"
     },
     "autoload": {
         "classmap": [
@@ -79,6 +83,11 @@
         "bin-dir": ".Build/bin",
         "preferred-install": {
             "typo3/cms": "source"
+        },
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true,
+            "phpstan/extension-installer": true
         }
     },
     "scripts": {
@@ -93,9 +102,15 @@
         "lint": [
             "@lint:php"
         ],
+        "phpstan:baseline": [
+            ".Build/bin/phpstan --generate-baseline=phpstan-baseline.neon"
+        ],
         "test:phpcs": [
             "[ -e .Build/bin/php-cs-fixer ] || composer update --ansi",
             ".Build/bin/php-cs-fixer fix -v --dry-run --diff --diff-format udiff --ansi"
+        ],
+        "test:phpstan": [
+            ".Build/bin/phpstan --no-progress"
         ],
         "test:phpunit": [
             "[ -e .Build/bin/phpunit ] || composer update --ansi",
@@ -112,6 +127,10 @@
         "fix": [
             "@fix:phpcs"
         ]
+    },
+    "scripts-descriptions": {
+        "test:phpstan": "Checks the types with PHPStan.",
+        "phpstan:baseline": "Updates the PHPStan baseline file to match the code."
     },
     "extra": {
         "typo3/cms": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,412 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property formidable_inlineconfmethods\\:\\:\\$oForm\\.$#"
+			count: 6
+			path: api/class.inlineconfmethods.php
+
+		-
+			message: "#^Call to an undefined method formidable_maindatasource\\:\\:setSyncData\\(\\)\\.$#"
+			count: 2
+			path: api/class.maindatasource.php
+
+		-
+			message: "#^Access to an undefined property formidable_mainobject\\:\\:\\$conf\\.$#"
+			count: 1
+			path: api/class.mainobject.php
+
+		-
+			message: "#^Undefined variable\\: \\$hiddenFields$#"
+			count: 1
+			path: api/class.mainrenderer.php
+
+		-
+			message: "#^Call to static method getTCAlabelField\\(\\) on an unknown class tx_staticinfotables_div\\.$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Method formidable_mainrenderlet\\:\\:initDependancies\\(\\) should return unknown_type but return statement is missing\\.$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$aDbItems$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$aSkinFeed$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$bPlain$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$isSubXml$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$sClass$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$sId$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Access to an undefined property formidable_mainscriptingmethods\\:\\:\\$oForm\\.$#"
+			count: 4
+			path: api/class.mainscriptingmethods.php
+
+		-
+			message: "#^Method formidable_mainvalidator\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: api/class.mainvalidator.php
+
+		-
+			message: "#^Method formidable_mainvalidator\\:\\:validateWidget\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: api/class.mainvalidator.php
+
+		-
+			message: "#^Access to an undefined property formidable_templatemethods\\:\\:\\$oForm\\.$#"
+			count: 33
+			path: api/class.templatemethods.php
+
+		-
+			message: "#^Access to an undefined property user_ameosformidable_cobj\\:\\:\\$oForm\\.$#"
+			count: 1
+			path: api/class.user_ameosformidable_cobj.php
+
+		-
+			message: "#^Undefined variable\\: \\$incFile$#"
+			count: 1
+			path: api/class.user_ameosformidable_cobj.php
+
+		-
+			message: "#^Method tx_mkforms_dh_db_Main\\:\\:_processAfterCreation\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: dh/db/class.tx_mkforms_dh_db_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$oForm$#"
+			count: 1
+			path: dh/dbmm/class.tx_mkforms_dh_dbmm_Main.php
+
+		-
+			message: "#^Call to static method getMailService\\(\\) on an unknown class tx_mkmailer_util_ServiceRegistry\\.$#"
+			count: 1
+			path: dh/mail/class.tx_mkforms_dh_mail_Main.php
+
+		-
+			message: "#^Class tx_mkmailer_models_Template not found\\.$#"
+			count: 1
+			path: dh/mail/class.tx_mkforms_dh_mail_Main.php
+
+		-
+			message: "#^Access to an undefined property formidableajax\\:\\:\\$ttStart\\.$#"
+			count: 1
+			path: remote/formidableajax.php
+
+		-
+			message: "#^Access to an undefined property formidableajax\\:\\:\\$ttTimes\\.$#"
+			count: 2
+			path: remote/formidableajax.php
+
+		-
+			message: "#^Method formidableajax\\:\\:denyService\\(\\) invoked with 0 parameters, 1 required\\.$#"
+			count: 1
+			path: remote/formidableajax.php
+
+		-
+			message: "#^Instantiated class Tx_Fluid_Compatibility_ObjectFactory not found\\.$#"
+			count: 1
+			path: renderer/fluid/class.tx_mkforms_renderer_fluid_Main.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_session_MixedSessionManager\\:\\:\\$bStoreParentInSession\\.$#"
+			count: 1
+			path: session/class.tx_mkforms_session_MixedSessionManager.php
+
+		-
+			message: "#^Access to static property \\$validatorWasCalled on an unknown class tx_mkforms_tests_api_mainrenderlet_testcase\\.$#"
+			count: 2
+			path: tests/fixtures/class.tx_mkforms_tests_fixtures_ValidatorHandlesAfterRenderCheckpoint.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Config\\:\\:\\$_aConf\\.$#"
+			count: 3
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Config\\:\\:\\$_xmlPath\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Config\\:\\:\\$form\\.$#"
+			count: 5
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Config\\:\\:\\$sLastXPathError\\.$#"
+			count: 2
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_isTrueVal\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_matchCondition\\(\\)\\.$#"
+			count: 2
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_matchConditions\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_substituteDynaXml\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:absolutizeXPath\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:getTcaVal\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Method tx_mkforms_util_Config\\:\\:compileConfig\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Undefined variable\\: \\$aIncHierarchy$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Undefined variable\\: \\$defaultPrefix$#"
+			count: 1
+			path: util/class.tx_mkforms_util_FormBase.php
+
+		-
+			message: "#^Undefined variable\\: \\$sPath$#"
+			count: 1
+			path: util/class.tx_mkforms_util_FormBase.php
+
+		-
+			message: "#^Static call to instance method tx_mkforms_util_FormBaseAjax\\:\\:evalSecureExpression\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_FormBaseAjax.php
+
+		-
+			message: "#^Undefined variable\\: \\$table$#"
+			count: 1
+			path: util/class.tx_mkforms_util_FormFill.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Json\\:\\:\\$use\\.$#"
+			count: 5
+			path: util/class.tx_mkforms_util_Json.php
+
+		-
+			message: "#^Method tx_mkforms_util_Json\\:\\:decode\\(\\) should return boollean but return statement is missing\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Json.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$__sEvalTemp\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$_xmlPath\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$aCB\\.$#"
+			count: 3
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$aLastTs\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$formid\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Undefined variable\\: \\$oCbObj$#"
+			count: 2
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Undefined variable\\: \\$sName$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Templates\\:\\:getLLLabel\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Templates.php
+
+		-
+			message: "#^Call to function unset\\(\\) contains undefined variable \\$tempTagValue\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_XMLParser.php
+
+		-
+			message: "#^Method tx_mkforms_validator_db_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/db/class.tx_mkforms_validator_db_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_file_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/file/class.tx_mkforms_validator_file_Main.php
+
+		-
+			message: "#^Function split not found\\.$#"
+			count: 1
+			path: validator/num/class.tx_mkforms_validator_num_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_num_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/num/class.tx_mkforms_validator_num_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_preg_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/preg/class.tx_mkforms_validator_preg_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_timetracking_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/timetracking/class.tx_mkforms_validator_timetracking_Main.php
+
+		-
+			message: "#^Static method Sys25\\\\RnBase\\\\Utility\\\\Strings\\:\\:trimExplode\\(\\) invoked with 1 parameter, 2\\-4 required\\.$#"
+			count: 1
+			path: widgets/box/class.tx_mkforms_widgets_box_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sLabel$#"
+			count: 1
+			path: widgets/box/class.tx_mkforms_widgets_box_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sScript$#"
+			count: 1
+			path: widgets/captcha/class.tx_mkforms_widgets_captcha_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$cryptoneuse$#"
+			count: 1
+			path: widgets/captcha/res/lib/cryptographp.fct.php
+
+		-
+			message: "#^Undefined variable\\: \\$cryptsecure$#"
+			count: 1
+			path: widgets/captcha/res/lib/cryptographp.fct.php
+
+		-
+			message: "#^Undefined variable\\: \\$difuplow$#"
+			count: 1
+			path: widgets/captcha/res/lib/cryptographp.fct.php
+
+		-
+			message: "#^Undefined variable\\: \\$sInput$#"
+			count: 1
+			path: widgets/checksingle/class.tx_mkforms_widgets_checksingle_Main.php
+
+		-
+			message: "#^Method tx_mkforms_widgets_chooser_Main\\:\\:_render\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: widgets/chooser/class.tx_mkforms_widgets_chooser_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sHtmlId$#"
+			count: 1
+			path: widgets/chooser/class.tx_mkforms_widgets_chooser_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sEmptyString$#"
+			count: 1
+			path: widgets/date/class.tx_mkforms_widgets_date_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$value$#"
+			count: 1
+			path: widgets/link/class.tx_mkforms_widgets_link_Main.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_widgets_lister_Main\\:\\:\\$__aCurRow\\.$#"
+			count: 4
+			path: widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_widgets_lister_Main\\:\\:\\$aTemplate\\.$#"
+			count: 2
+			path: widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sMessage$#"
+			count: 1
+			path: widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sNamePrefix$#"
+			count: 1
+			path: widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_widgets_listerselect_Main\\:\\:\\$aSubWidgets\\.$#"
+			count: 2
+			path: widgets/listerselect/class.tx_mkforms_widgets_listerselect_Main.php
+
+		-
+			message: "#^Method tx_mkforms_widgets_listerselect_Main\\:\\:addSelectorId\\(\\) should return unknown_type but return statement is missing\\.$#"
+			count: 1
+			path: widgets/listerselect/class.tx_mkforms_widgets_listerselect_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$aItem$#"
+			count: 1
+			path: widgets/listerselect/class.tx_mkforms_widgets_listerselect_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sLabel$#"
+			count: 1
+			path: widgets/searchform/class.tx_mkforms_widgets_searchform_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sLabel$#"
+			count: 1
+			path: widgets/tab/class.tx_mkforms_widgets_tab_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sLabel$#"
+			count: 1
+			path: widgets/tabpanel/class.tx_mkforms_widgets_tabpanel_Main.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,75 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+  parallel:
+      # Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
+      maximumNumberOfProcesses: 5
+
+  level: 0
+
+  bootstrapFiles:
+    - .Build/vendor/autoload.php
+
+  paths:
+    - action
+    - api
+    - Classes
+    - dh
+    - ds
+    - exception
+    - forms
+    - hooks
+    - remote
+    - renderer
+    - session
+    - tests
+    - util
+    - validator
+    - view
+    - widgets
+
+  scanDirectories:
+    - action
+    - api
+    - Classes
+    - dh
+    - ds
+    - exception
+    - forms
+    - hooks
+    - remote
+    - renderer
+    - session
+    - tests
+    - util
+    - validator
+    - view
+    - widgets
+
+  # These files create errors for PHPStan. We need to fix those before we can include them.
+  excludePaths:
+    - Classes/Frontend/FormBase.php
+    - action/class.tx_mkforms_action_FormBase.php
+    - api/class.tx_ameosformidable.php
+    - api/class.tx_ameosformidable_pi.php
+    - ds/contentrepository/class.tx_mkforms_ds_contentrepository_Main.php
+    - tests/action/class.tx_mkforms_tests_action_FormBaseTest.php
+    - tests/api/class.tx_mkforms_tests_api_maindatahandlerTest.php
+    - tests/api/class.tx_mkforms_tests_api_mainrendererTest.php
+    - tests/api/class.tx_mkforms_tests_api_mainrenderletTest.php
+    - tests/api/class.tx_mkforms_tests_api_mainvalidatorTest.php
+    - tests/api/class.tx_mkforms_tests_api_tx_ameosformidableTest.php
+    - tests/util/class.tx_mkforms_tests_util_DivTest.php
+    - tests/util/class.tx_mkforms_tests_util_FormBaseAjaxTest.php
+    - tests/util/class.tx_mkforms_tests_util_FormBaseTest.php
+    - tests/util/class.tx_mkforms_tests_util_FormFillTest.php
+    - tests/util/class.tx_mkforms_tests_util_JsonTest.php
+    - tests/util/class.tx_mkforms_tests_util_TemplatesTest.php
+    - tests/validator/timetracking/class.tx_mkforms_tests_validator_timetracking_MainTest.php
+    - tests/widgets/class.tx_mkforms_tests_widgets_fluidviewhelperTest.php
+    - tests/widgets/class.tx_mkforms_tests_widgets_text_MainTest.php
+    - widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
+    - widgets/progressbar/class.tx_mkforms_widgets_progressbar_Main.php
+    - widgets/swfupload/class.tx_mkforms_widgets_swfupload_Main.php
+    - widgets/ticker/class.tx_mkforms_widgets_ticker_Main.php


### PR DESCRIPTION
Add PHPStan to the CI builds and also add Composer commands for
running PHPStan and for updating the baseline.

For starters, exclude files that currently break PHPStan
(either due to autoloading problems from rn_base or due to
other problems).

This is the plan:

1. Start with level 0 and put all errors in the baseline.
2. Update rn_base and include more files that had autoloading problems.
3. Fix the excluded files so we can include them in scan.
4. Fix all level 0 warnings.
5. Raise the level to 1 and put all warnings in the baseline.
6. Rinse and repeat for all levels.