### PR TITLE
[TASK] Require rn_base ~1.13.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.2",
         "typo3/cms-core": "^9.5 || ^10.4",
-        "digedag/rn-base": "~1.13.0"
+        "digedag/rn-base": "~1.13.15"
     },
     "require-dev": {
         "nimut/testing-framework": "^4.0 || ^5.0",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -33,9 +33,9 @@ $EM_CONF['mkforms'] = [
     'CGLcompliance_note' => '',
     'constraints' => [
         'depends' => [
-            'rn_base' => '1.10.5-',
             'typo3' => '9.5.0-10.4.99',
             'php' => '7.2.0-7.4.99',
+            'rn_base' => '1.13.15-1.13.99',
         ],
         'conflicts' => [
             'ameos_formidable' => '',


### PR DESCRIPTION
This makes sure that we can rely on the changes that have been introduced
between rn_base 1.13.0 and 1.13.15.

Also fix the upper boundary for rn_base in `ext_emconf.php`.