### PR TITLE
[BUGFIX] Automatically create the assets and cache directories

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,7 +22,6 @@ $EM_CONF['mkforms'] = [
     'module' => '',
     'state' => 'stable',
     'uploadfolder' => 0,
-    'createDirs' => 'typo3temp/mkforms/cache/,typo3temp/assets/mkforms/',
     'modify_tables' => '',
     'clearcacheonload' => 1,
     'lockType' => '',

--- a/js/class.tx_mkforms_js_Loader.php
+++ b/js/class.tx_mkforms_js_Loader.php
@@ -1,5 +1,8 @@
 <?php
 
+use Sys25\RnBase\Utility\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Diese Klasse bindet das notwendige Javascript ein. Es ist eine neue Fassung der
  * Klasse formidable_jslayer.
@@ -545,28 +548,32 @@ JAVASCRIPT;
                 $sDesc = "\n\n<!-- MKFORMS: ".str_replace(['<!--', '-->'], '', $sDesc).' -->';
             }
 
+            $directory = 'typo3temp/assets/mkforms/';
             // Create filename / tags:
             $script = '';
             switch ($ext) {
                 case 'js':
-                    $script = 'typo3temp/assets/mkforms/javascript_'.substr(md5($str), 0, 10).'.js';
+                    $script = 'javascript_'.substr(md5($str), 0, 10).'.js';
                     $output = $sDesc."\n".'<script src="'.htmlspecialchars(
-                        $this->getAbsRefPrefix().$script
+                        $this->getAbsRefPrefix().$directory.$script
                     ).'"></script>'."\n\n";
                     break;
 
                 case 'css':
-                    $script = 'typo3temp/assets/mkforms/stylesheet_'.substr(md5($str), 0, 10).'.css';
+                    $script = 'stylesheet_'.substr(md5($str), 0, 10).'.css';
                     $output = $sDesc."\n".'<link rel="stylesheet" type="text/css" href="'.htmlspecialchars(
-                        $this->getAbsRefPrefix().$script
+                        $this->getAbsRefPrefix().$directory.$script
                     ).'" />'."\n\n";
                     break;
             }
 
             // Write file:
             if ($script) {
-                if (!@is_file(\Sys25\RnBase\Utility\Environment::getPublicPath().$script)) {
-                    Tx_Rnbase_Utility_T3General::writeFile(\Sys25\RnBase\Utility\Environment::getPublicPath().$script, $str);
+                if (!\is_dir($directory)) {
+                    GeneralUtility::mkdir_deep($directory);
+                }
+                if (!@is_file(Environment::getPublicPath().$directory.$script)) {
+                    Tx_Rnbase_Utility_T3General::writeFile(Environment::getPublicPath().$directory.$script, $str);
                 }
             }
         }

--- a/util/class.tx_mkforms_util_XMLParser.php
+++ b/util/class.tx_mkforms_util_XMLParser.php
@@ -22,6 +22,9 @@
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use Sys25\RnBase\Utility\Environment;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
 /**
  * Loading classes.
  */
@@ -80,8 +83,11 @@ class tx_mkforms_util_XMLParser
 
             $sHash = md5($sPath.'-'.@filemtime($sPath).'-'.tx_mkforms_util_Div::getVersion());
             $sFile = 'xmlcache_'.$sHash.'.php';
-            $sCacheDir = 'mkforms/cache/';
-            $sCachePath = \Sys25\RnBase\Utility\Environment::getPublicPath().'typo3temp/'.$sCacheDir.$sFile;
+            $sCacheDir = Environment::getPublicPath().'typo3temp/mkforms/cache/';
+            if (!\is_dir($sCacheDir)) {
+                GeneralUtility::mkdir_deep($sCacheDir);
+            }
+            $sCachePath = $sCacheDir.$sFile;
 
             if (file_exists($sCachePath)) {
                 $aConf = unserialize(


### PR DESCRIPTION
TYPO3 10LTS does not automatically create the directories set as
`createDirs` in the `ext_emconf.php`. So to make sure files can
be written to these directories (which fixes a crash in the frontend),
the directories need to be checked and created before writing to them.