### PR TITLE
[TASK] Enable Composer plugins for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,10 @@
         "bin-dir": ".Build/bin",
         "preferred-install": {
             "typo3/cms": "source"
+        },
+        "allow-plugins": {
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
         }
     },
     "scripts": {


### PR DESCRIPTION
This avoids changes for the `composer.json` when running
`composer install` with Composer >= 2.2.