### PR TITLE
[FEATURE] Add type checking with PHPStan to the toolchain

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,6 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.php_cs export-ignore
+/phpstan-baseline.neon export-ignore
+/phpstan.neon export-ignore
 /phpunit.xml.dist export-ignore

--- a/.github/workflows/phpci.yml
+++ b/.github/workflows/phpci.yml
@@ -64,6 +64,7 @@ jobs:
             matrix:
                 command:
                     - "test:phpcs"
+                    - "test:phpstan"
                     - "test:phpcompatibility"
                 php-version:
                     - "7.4"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,11 @@
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"friendsofphp/php-cs-fixer": "^3.3",
 		"phpcompatibility/php-compatibility": "^9.3.5",
-		"nimut/testing-framework": "^6.0"
+		"nimut/testing-framework": "^6.0",
+        "phpstan/extension-installer": "^1.1.0",
+        "phpstan/phpstan": "^1.7.8",
+        "phpstan/phpstan-phpunit": "^1.1.1",
+        "saschaegerer/phpstan-typo3": "^1.1.2"
     },
     "autoload": {
         "classmap": [
@@ -99,6 +103,9 @@
         "lint": [
             "@lint:php"
         ],
+		"phpstan:baseline": [
+			".Build/bin/phpstan --generate-baseline=phpstan-baseline.neon"
+		],
         "test:phpcs": [
             "[ -e .Build/bin/php-cs-fixer ] || composer update --ansi",
             ".Build/bin/php-cs-fixer fix -v --dry-run --diff --ansi"
@@ -115,6 +122,9 @@
 			"[ -e .Build/bin/phpcs ] || composer update",
 			".Build/bin/phpcs --ignore=.Build/*,Resources/Public/JavaScript/* -p . --standard=.Build/vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.0"
 		],
+		"test:phpstan": [
+			".Build/bin/phpstan --no-progress"
+		],
         "test:phpunit": [
             "[ -e .Build/bin/phpunit ] || composer update --ansi",
             "export TYPO3_PATH_WEB=$PWD/.Build/Web && .Build/bin/phpunit --colors=always "
@@ -122,6 +132,7 @@
         "test": [
             "@test:phpcs",
 			"@test:phpcompatibility",
+			"@test:phpstan",
             "@test:phpunit"
         ],
         "fix:phpcs": [
@@ -136,6 +147,10 @@
 			"@lint",
 			"@test"
 		]
+	},
+	"scripts-descriptions": {
+		"test:phpstan": "Checks the types with PHPStan.",
+		"phpstan:baseline": "Updates the PHPStan baseline file to match the code."
 	},
     "extra": {
 		"branch-alias": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,387 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Class DMK\\\\Mkforms\\\\Middleware\\\\HeaderInjection referenced with incorrect case\\: DMK\\\\MkForms\\\\Middleware\\\\HeaderInjection\\.$#"
+			count: 1
+			path: Configuration/RequestMiddlewares.php
+
+		-
+			message: "#^Access to an undefined property formidable_inlineconfmethods\\:\\:\\$oForm\\.$#"
+			count: 6
+			path: api/class.inlineconfmethods.php
+
+		-
+			message: "#^Call to an undefined method formidable_maindatasource\\:\\:setSyncData\\(\\)\\.$#"
+			count: 2
+			path: api/class.maindatasource.php
+
+		-
+			message: "#^Access to an undefined property formidable_mainobject\\:\\:\\$conf\\.$#"
+			count: 1
+			path: api/class.mainobject.php
+
+		-
+			message: "#^Call to static method getTCAlabelField\\(\\) on an unknown class tx_staticinfotables_div\\.$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Method formidable_mainrenderlet\\:\\:initDependancies\\(\\) should return unknown_type but return statement is missing\\.$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$aSkinFeed$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$bPlain$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$isSubXml$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Undefined variable\\: \\$sClass$#"
+			count: 1
+			path: api/class.mainrenderlet.php
+
+		-
+			message: "#^Access to an undefined property formidable_mainscriptingmethods\\:\\:\\$oForm\\.$#"
+			count: 4
+			path: api/class.mainscriptingmethods.php
+
+		-
+			message: "#^Method formidable_mainvalidator\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: api/class.mainvalidator.php
+
+		-
+			message: "#^Method formidable_mainvalidator\\:\\:validateWidget\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: api/class.mainvalidator.php
+
+		-
+			message: "#^Access to an undefined property formidable_templatemethods\\:\\:\\$oForm\\.$#"
+			count: 33
+			path: api/class.templatemethods.php
+
+		-
+			message: "#^Access to an undefined property tx_ameosformidable\\:\\:\\$__sEvalTemp\\.$#"
+			count: 3
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Access to an undefined property tx_ameosformidable\\:\\:\\$_aSubXmlCache\\.$#"
+			count: 1
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Access to an undefined property tx_ameosformidable\\:\\:\\$bReliableXML\\.$#"
+			count: 1
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Access to an undefined property tx_ameosformidable\\:\\:\\$end_tstamp\\.$#"
+			count: 2
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Access to an undefined property tx_ameosformidable\\:\\:\\$sDefaultLLLPrefix\\.$#"
+			count: 2
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Access to an undefined property tx_ameosformidable\\:\\:\\$sDefaultWrapClass\\.$#"
+			count: 1
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Call to static method fromPath\\(\\) on an unknown class Swift_Attachment\\.$#"
+			count: 1
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Instantiated class CSV not found\\.$#"
+			count: 1
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Method tx_ameosformidable\\:\\:handleAjaxRequest\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Undefined variable\\: \\$sType$#"
+			count: 2
+			path: api/class.tx_ameosformidable.php
+
+		-
+			message: "#^Call to an undefined static method tx_ameosformidable\\:\\:toServerPath\\(\\)\\.$#"
+			count: 2
+			path: api/class.tx_ameosformidable_pi.php
+
+		-
+			message: "#^Access to an undefined property user_ameosformidable_cobj\\:\\:\\$oForm\\.$#"
+			count: 1
+			path: api/class.user_ameosformidable_cobj.php
+
+		-
+			message: "#^Undefined variable\\: \\$incFile$#"
+			count: 1
+			path: api/class.user_ameosformidable_cobj.php
+
+		-
+			message: "#^Method tx_mkforms_dh_db_Main\\:\\:_processAfterCreation\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: dh/db/class.tx_mkforms_dh_db_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$oForm$#"
+			count: 1
+			path: dh/dbmm/class.tx_mkforms_dh_dbmm_Main.php
+
+		-
+			message: "#^Call to static method getMailService\\(\\) on an unknown class tx_mkmailer_util_ServiceRegistry\\.$#"
+			count: 1
+			path: dh/mail/class.tx_mkforms_dh_mail_Main.php
+
+		-
+			message: "#^Class tx_mkmailer_models_Template not found\\.$#"
+			count: 1
+			path: dh/mail/class.tx_mkforms_dh_mail_Main.php
+
+		-
+			message: "#^Access to an undefined property formidableajax\\:\\:\\$ttStart\\.$#"
+			count: 1
+			path: remote/formidableajax.php
+
+		-
+			message: "#^Access to an undefined property formidableajax\\:\\:\\$ttTimes\\.$#"
+			count: 2
+			path: remote/formidableajax.php
+
+		-
+			message: "#^Method formidableajax\\:\\:denyService\\(\\) invoked with 0 parameters, 1 required\\.$#"
+			count: 1
+			path: remote/formidableajax.php
+
+		-
+			message: "#^Instantiated class Tx_Fluid_Compatibility_ObjectFactory not found\\.$#"
+			count: 1
+			path: renderer/fluid/class.tx_mkforms_renderer_fluid_Main.php
+
+		-
+			message: "#^Call to an undefined static method tx_mkforms_tests_action_FormBaseTest\\:\\:assertInternalType\\(\\)\\.$#"
+			count: 6
+			path: tests/action/class.tx_mkforms_tests_action_FormBaseTest.php
+
+		-
+			message: "#^Call to an undefined static method tx_mkforms_tests_api_tx_ameosformidableTest\\:\\:assertInternalType\\(\\)\\.$#"
+			count: 1
+			path: tests/api/class.tx_mkforms_tests_api_tx_ameosformidableTest.php
+
+		-
+			message: "#^Array has 11 duplicate keys with value 'line 121' \\('line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__, 'line ' \\. __LINE__\\)\\.$#"
+			count: 1
+			path: tests/util/class.tx_mkforms_tests_util_DivTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$timetrackingWidget$#"
+			count: 1
+			path: tests/validator/timetracking/class.tx_mkforms_tests_validator_timetracking_MainTest.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Config\\:\\:\\$_xmlPath\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Config\\:\\:\\$form\\.$#"
+			count: 5
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Config\\:\\:\\$sLastXPathError\\.$#"
+			count: 2
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_isTrueVal\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_matchCondition\\(\\)\\.$#"
+			count: 2
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_matchConditions\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:_substituteDynaXml\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:absolutizeXPath\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Config\\:\\:getTcaVal\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Method tx_mkforms_util_Config\\:\\:compileConfig\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Config.php
+
+		-
+			message: "#^Undefined variable\\: \\$sPath$#"
+			count: 1
+			path: util/class.tx_mkforms_util_FormBase.php
+
+		-
+			message: "#^Static call to instance method tx_mkforms_util_FormBaseAjax\\:\\:evalSecureExpression\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_FormBaseAjax.php
+
+		-
+			message: "#^Undefined variable\\: \\$table$#"
+			count: 1
+			path: util/class.tx_mkforms_util_FormFill.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Json\\:\\:\\$use\\.$#"
+			count: 5
+			path: util/class.tx_mkforms_util_Json.php
+
+		-
+			message: "#^Method tx_mkforms_util_Json\\:\\:decode\\(\\) should return boollean but return statement is missing\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Json.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$__sEvalTemp\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$aCB\\.$#"
+			count: 2
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_util_Runnable\\:\\:\\$aLastTs\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Undefined variable\\: \\$oCbObj$#"
+			count: 2
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Undefined variable\\: \\$sName$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Runnable.php
+
+		-
+			message: "#^Call to an undefined method tx_mkforms_util_Templates\\:\\:getLLLabel\\(\\)\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_Templates.php
+
+		-
+			message: "#^Call to function unset\\(\\) contains undefined variable \\$tempTagValue\\.$#"
+			count: 1
+			path: util/class.tx_mkforms_util_XMLParser.php
+
+		-
+			message: "#^Method tx_mkforms_validator_db_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/db/class.tx_mkforms_validator_db_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_file_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/file/class.tx_mkforms_validator_file_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_num_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/num/class.tx_mkforms_validator_num_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_preg_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/preg/class.tx_mkforms_validator_preg_Main.php
+
+		-
+			message: "#^Method tx_mkforms_validator_timetracking_Main\\:\\:validate\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: validator/timetracking/class.tx_mkforms_validator_timetracking_Main.php
+
+		-
+			message: "#^Static method Sys25\\\\RnBase\\\\Utility\\\\Strings\\:\\:trimExplode\\(\\) invoked with 1 parameter, 2\\-4 required\\.$#"
+			count: 1
+			path: widgets/box/class.tx_mkforms_widgets_box_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sScript$#"
+			count: 1
+			path: widgets/captcha/class.tx_mkforms_widgets_captcha_Main.php
+
+		-
+			message: "#^Method tx_mkforms_widgets_chooser_Main\\:\\:_render\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: widgets/chooser/class.tx_mkforms_widgets_chooser_Main.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_widgets_lister_Main\\:\\:\\$__aCurRow\\.$#"
+			count: 4
+			path: widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+
+		-
+			message: "#^Access to an undefined property tx_mkforms_widgets_lister_Main\\:\\:\\$aTemplate\\.$#"
+			count: 2
+			path: widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sMessage$#"
+			count: 1
+			path: widgets/lister/class.tx_mkforms_widgets_lister_Main.php
+
+		-
+			message: "#^Method tx_mkforms_widgets_listerselect_Main\\:\\:addSelectorId\\(\\) should return unknown_type but return statement is missing\\.$#"
+			count: 1
+			path: widgets/listerselect/class.tx_mkforms_widgets_listerselect_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sLabel$#"
+			count: 1
+			path: widgets/searchform/class.tx_mkforms_widgets_searchform_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sLabel$#"
+			count: 1
+			path: widgets/tab/class.tx_mkforms_widgets_tab_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$sLabel$#"
+			count: 1
+			path: widgets/tabpanel/class.tx_mkforms_widgets_tabpanel_Main.php
+
+		-
+			message: "#^Undefined variable\\: \\$aChildsBag$#"
+			count: 1
+			path: widgets/ticker/class.tx_mkforms_widgets_ticker_Main.php
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,59 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+  parallel:
+      # Don't be overly greedy on machines with more CPU's to be a good neighbor especially on CI
+      maximumNumberOfProcesses: 5
+
+  level: 0
+
+  bootstrapFiles:
+    - .Build/vendor/autoload.php
+
+  paths:
+    - Classes
+    - Configuration
+    - action
+    - api
+    - dh
+    - ds
+    - exception
+    - forms
+    - js
+    - remote
+    - renderer
+    - session
+    - tests
+    - util
+    - validator
+    - view
+    - widgets
+
+  scanDirectories:
+    - Classes
+    - Configuration
+    - action
+    - api
+    - dh
+    - ds
+    - exception
+    - forms
+    - js
+    - remote
+    - renderer
+    - session
+    - tests
+    - util
+    - validator
+    - view
+    - widgets
+
+  # These files create errors for PHPStan. We need to fix those before we can include them.
+  excludePaths:
+    - Classes/Frontend/FormBase.php
+    - action/class.tx_mkforms_action_FormBase.php
+    - ds/contentrepository/class.tx_mkforms_ds_contentrepository_Main.php
+    - widgets/mediaupload/class.tx_mkforms_widgets_mediaupload_Main.php
+    - widgets/progressbar/class.tx_mkforms_widgets_progressbar_Main.php
+    - widgets/swfupload/class.tx_mkforms_widgets_swfupload_Main.php


### PR DESCRIPTION
This change also adds to new Composer commands:

- `composer test:phpstan` to check the code with PHPStan
- `composer phpstan:baseline` to re-generate the baseline file

We're starting with level 0. Once we've fixed most of the problems
listed in the baseline file, we can raise the level one by one.