### PR TITLE
[BUGFIX] correct namespace case for HeaderInjection

### DIFF
--- a/Classes/Middleware/HeaderInjection.php
+++ b/Classes/Middleware/HeaderInjection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DMK\Mkforms\Middleware;
+namespace DMK\MkForms\Middleware;
 
 /***************************************************************
  * Copyright notice


### PR DESCRIPTION
```
[ Symfony\Component\DependencyInjection\Exception\InvalidArgumentException ]  
Expected to find class "DMK\MkForms\Middleware\HeaderInjection" in file 
"/typo3conf/ext/mkforms/Classes/Middleware/HeaderInjection.php" while 
importing services from resource "../Classes/*", but it was not found! Check 
the namespace prefix used with the resource.  
 ```    

This won't create an exception in all circumstances it seems but after deploying and running `language:update` (thus doing a full bootstrap on a pristine uncached system state) this can happen.